### PR TITLE
fix: Docker DB init failures - authority_menu view and casbin v1 colu…

### DIFF
--- a/server/service/sys_initdb.go
+++ b/server/service/sys_initdb.go
@@ -127,9 +127,9 @@ func InitDB(conf request.InitDB) error {
 	err = initDB(
 		source.Admin,
 		source.Api,
-		source.AuthorityMenu,
 		source.Authority,
 		source.AuthoritiesMenus,
+		source.AuthorityMenu,
 		source.Casbin,
 		source.DataAuthorities,
 		source.Dictionary,

--- a/server/source/casbin.go
+++ b/server/source/casbin.go
@@ -107,6 +107,7 @@ var carbines = []gormadapter.CasbinRule{
 
 func (c *casbin) Init() error {
 	global.GVA_DB.AutoMigrate(gormadapter.CasbinRule{})
+	global.GVA_DB.Exec("ALTER TABLE casbin_rule MODIFY COLUMN v1 VARCHAR(100)")
 	return global.GVA_DB.Transaction(func(tx *gorm.DB) error {
 		if tx.Find(&[]gormadapter.CasbinRule{}).RowsAffected > 1 {
 			color.Danger.Println("\n[Mysql] --> casbin_rule 表的初始数据已存在!")


### PR DESCRIPTION
…mn size

Fix two issues causing database initialization to fail on fresh Docker deployments (closes #293):

1. Reorder init sequence: move Authority and AuthoritiesMenus before AuthorityMenu. The authority_menu VIEW depends on sys_authority_menus data, so AuthoritiesMenus must be seeded first.

2. Widen casbin_rule.v1 column from varchar(40) to varchar(100) via ALTER TABLE after AutoMigrate. The gorm-adapter defaults v1 to varchar(40), but several API paths exceed 40 characters.