### PR TITLE
fix: correct casbin table name in ALTER TABLE statement

### DIFF
--- a/server/source/casbin.go
+++ b/server/source/casbin.go
@@ -107,7 +107,7 @@ var carbines = []gormadapter.CasbinRule{
 
 func (c *casbin) Init() error {
 	global.GVA_DB.AutoMigrate(gormadapter.CasbinRule{})
-	global.GVA_DB.Exec("ALTER TABLE casbin_rule MODIFY COLUMN v1 VARCHAR(100)")
+	global.GVA_DB.Exec("ALTER TABLE casbin_rules MODIFY COLUMN v1 VARCHAR(100)")
 	return global.GVA_DB.Transaction(func(tx *gorm.DB) error {
 		if tx.Find(&[]gormadapter.CasbinRule{}).RowsAffected > 1 {
 			color.Danger.Println("\n[Mysql] --> casbin_rule 表的初始数据已存在!")


### PR DESCRIPTION
GORM auto-pluralizes CasbinRule to casbin_rules, but the ALTER TABLE was using casbin_rule (singular), causing the column widening to fail silently on a non-existent table.