### PR TITLE
fix: use multi-arch MySQL image for arm64 compatibility

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,13 +8,14 @@ networks:
 
 services:
   mysql:
-    image: mysql:8.0.21       # 如果您是 arm64 架构：如 MacOS 的 M1，请修改镜像为 image: mysql/mysql-server:8.0.21
+    image: mysql/mysql-server:8.0.21
     container_name: gshark-mysql
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     restart: "always"
     ports:
       - "13306:3306"  # host物理直接映射端口为13306
     environment:
+      MYSQL_ROOT_HOST: "%"
       MYSQL_DATABASE:
       MYSQL_ROOT_PASSWORD: 'madneal'
       MYSQL_USER: 'gshark'


### PR DESCRIPTION
Replace mysql:8.0.21 (amd64 only) with mysql/mysql-server:8.0.21 which supports both amd64 and arm64. Add MYSQL_ROOT_HOST: "%" to allow root remote connections, matching the existing config.docker.yaml which uses root credentials.