### PR TITLE
Fix Casbin runtime initialization panic

### DIFF
--- a/server/api/sys_casbin.go
+++ b/server/api/sys_casbin.go
@@ -32,6 +32,11 @@ func GetPolicyPathByAuthorityId(c *gin.Context) {
 		response.FailWithMessage(err.Error(), c)
 		return
 	}
-	paths := service.GetPolicyPathByAuthorityId(casbin.AuthorityId)
+	paths, err := service.GetPolicyPathByAuthorityId(casbin.AuthorityId)
+	if err != nil {
+		global.GVA_LOG.Error("获取失败!", zap.Any("err", err))
+		response.FailWithMessage("获取失败", c)
+		return
+	}
 	response.OkWithDetailed(response.PolicyPathResponse{Paths: paths}, "获取成功", c)
 }

--- a/server/middleware/casbin_rbac.go
+++ b/server/middleware/casbin_rbac.go
@@ -8,7 +8,6 @@ import (
 	"github.com/madneal/gshark/service"
 )
 
-
 func CasbinHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		claims, _ := c.Get("claims")
@@ -19,7 +18,12 @@ func CasbinHandler() gin.HandlerFunc {
 		act := c.Request.Method
 		// 获取用户的角色
 		sub := waitUse.AuthorityId
-		e := service.Casbin()
+		e, err := service.Casbin()
+		if err != nil {
+			response.FailWithDetailed(gin.H{}, "权限初始化失败", c)
+			c.Abort()
+			return
+		}
 		// 判断策略中是否存在
 		success, _ := e.Enforce(sub, obj, act)
 		if global.GVA_CONFIG.System.Env == "develop" || success {

--- a/server/service/sys_authority.go
+++ b/server/service/sys_authority.go
@@ -36,7 +36,11 @@ func CopyAuthority(copyInfo response.SysAuthorityCopyResponse) (err error, autho
 	copyInfo.Authority.SysBaseMenus = baseMenu
 	err = global.GVA_DB.Create(&copyInfo.Authority).Error
 
-	paths := GetPolicyPathByAuthorityId(copyInfo.OldAuthorityId)
+	paths, err := GetPolicyPathByAuthorityId(copyInfo.OldAuthorityId)
+	if err != nil {
+		_ = DeleteAuthority(&copyInfo.Authority)
+		return err, copyInfo.Authority
+	}
 	err = UpdateCasbin(copyInfo.Authority.AuthorityId, paths)
 	if err != nil {
 		_ = DeleteAuthority(&copyInfo.Authority)

--- a/server/service/sys_casbin.go
+++ b/server/service/sys_casbin.go
@@ -25,7 +25,10 @@ func UpdateCasbin(authorityId string, casbinInfos []request.CasbinInfo) error {
 		}
 		rules = append(rules, []string{cm.AuthorityId, cm.Path, cm.Method})
 	}
-	e := Casbin()
+	e, err := Casbin()
+	if err != nil {
+		return err
+	}
 	success, _ := e.AddPolicies(rules)
 	if success == false {
 		return errors.New("存在相同api,添加失败,请联系管理员")
@@ -41,8 +44,11 @@ func UpdateCasbinApi(oldPath string, newPath string, oldMethod string, newMethod
 	return err
 }
 
-func GetPolicyPathByAuthorityId(authorityId string) (pathMaps []request.CasbinInfo) {
-	e := Casbin()
+func GetPolicyPathByAuthorityId(authorityId string) (pathMaps []request.CasbinInfo, err error) {
+	e, err := Casbin()
+	if err != nil {
+		return nil, err
+	}
 	list := e.GetFilteredPolicy(0, authorityId)
 	for _, v := range list {
 		pathMaps = append(pathMaps, request.CasbinInfo{
@@ -50,23 +56,48 @@ func GetPolicyPathByAuthorityId(authorityId string) (pathMaps []request.CasbinIn
 			Method: v[2],
 		})
 	}
-	return pathMaps
+	return pathMaps, nil
 }
 
 func ClearCasbin(v int, p ...string) bool {
-	e := Casbin()
+	e, err := Casbin()
+	if err != nil {
+		return false
+	}
 	success, _ := e.RemoveFilteredPolicy(v, p...)
 	return success
 
 }
 
-func Casbin() *casbin.Enforcer {
-	admin := global.GVA_CONFIG.Mysql
-	a, _ := gormadapter.NewAdapter(global.GVA_CONFIG.System.DbType, admin.Username+":"+admin.Password+"@("+admin.Path+")/"+admin.Dbname, true)
-	e, _ := casbin.NewEnforcer(global.GVA_CONFIG.Casbin.ModelPath, a)
+func Casbin() (*casbin.Enforcer, error) {
+	if err := repairLegacyCasbinPTypeColumn(); err != nil {
+		return nil, err
+	}
+	a, err := gormadapter.NewAdapterByDB(global.GVA_DB)
+	if err != nil {
+		return nil, err
+	}
+	e, err := casbin.NewEnforcer(global.GVA_CONFIG.Casbin.ModelPath, a)
+	if err != nil {
+		return nil, err
+	}
 	e.AddFunction("ParamsMatch", ParamsMatchFunc)
-	_ = e.LoadPolicy()
-	return e
+	if err := e.LoadPolicy(); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+func repairLegacyCasbinPTypeColumn() error {
+	migrator := global.GVA_DB.Migrator()
+	if !migrator.HasTable("casbin_rule") {
+		return nil
+	}
+	if !migrator.HasColumn("casbin_rule", "p_type") || !migrator.HasColumn("casbin_rule", "ptype") {
+		return nil
+	}
+	// Repair rows written by adapter versions that used ptype instead of p_type.
+	return global.GVA_DB.Exec("UPDATE casbin_rule SET p_type = ptype WHERE (p_type IS NULL OR p_type = '') AND ptype IS NOT NULL AND ptype <> ''").Error
 }
 
 func ParamsMatch(fullNameKey1 string, key2 string) bool {

--- a/server/source/casbin.go
+++ b/server/source/casbin.go
@@ -111,7 +111,9 @@ var carbines = []gormadapter.CasbinRule{
 }
 
 func (c *casbin) Init() error {
-	global.GVA_DB.AutoMigrate(gormadapter.CasbinRule{})
+	if err := global.GVA_DB.AutoMigrate(gormadapter.CasbinRule{}); err != nil {
+		return err
+	}
 	return global.GVA_DB.Transaction(func(tx *gorm.DB) error {
 		inserted := 0
 		for _, rule := range carbines {


### PR DESCRIPTION
## Summary
- reuse the initialized GORM DB for Casbin runtime adapter creation
- return adapter/enforcer/load errors instead of panicking on nil enforcers
- propagate Casbin initialization errors through middleware/API/service call sites
- return AutoMigrate errors during Casbin seed initialization

## Verification
- GO111MODULE=on go test ./source ./middleware ./router ./api ./service with an empty-test regex