### PR TITLE
fix(web): status filter display, toolbar spacing, system config route

### DIFF
--- a/web/src/store/module/router.js
+++ b/web/src/store/module/router.js
@@ -14,6 +14,22 @@ const formatRouter = (routes) => {
     })
 }
 
+// Parents with children but no redirect land on an empty nested outlet
+// (or worse, unmatched paths). Default to the first visible child.
+const applyParentRedirects = (routes) => {
+    routes && routes.forEach(item => {
+        if (item.children && item.children.length > 0) {
+            applyParentRedirects(item.children)
+            if (!item.redirect) {
+                const first = item.children.find(ch => !ch.hidden && ch.name)
+                if (first) {
+                    item.redirect = { name: first.name }
+                }
+            }
+        }
+    })
+}
+
 export const router = {
     namespaced: true,
     state: {
@@ -56,6 +72,7 @@ export const router = {
                 component: 'view/error/index.vue'
             })
             formatRouter(asyncRouter)
+            applyParentRedirects(asyncRouter)
             baseRouter[0].children = asyncRouter
             baseRouter.push({
                 path: '/:pathMatch(.*)*',

--- a/web/src/style/main.scss
+++ b/web/src/style/main.scss
@@ -2269,6 +2269,16 @@ body {
             margin: 0 0 10px;
         }
 
+        // Adjacent buttons in one form-item (e.g. 查询/新增/批量删除) lost
+        // Element Plus margin because we zero .search-term .el-button+.el-button;
+        // use gap so toolbar buttons keep even spacing.
+        .el-form-item__content {
+            display: inline-flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
         .el-form-item__label {
             height: 32px;
             line-height: 32px;

--- a/web/src/view/searchResult/searchResult.vue
+++ b/web/src/view/searchResult/searchResult.vue
@@ -24,7 +24,6 @@
             clearable
             placeholder="全部"
             style="width: 120px"
-            @clear="searchInfo.status = -1"
           >
             <el-option
               v-for="item in statusOptions"
@@ -167,9 +166,11 @@ export default {
       type: "",
       taskButtonTxt: "启动二次过滤",
       taskBtnDisable: false,
-      // -1 = 全部 (backend skips status filter when Status < 0)
+      // null shows placeholder "全部"; normalizeSearchInfo maps it to -1 for the API
+      // (backend skips status filter when Status < 0). Do not bind -1 to the select —
+      // it is not in statusOptions and would render as the literal "-1".
       searchInfo: {
-        status: -1,
+        status: null,
       },
       statusOptions: [
         { label: "未处理", value: 0 },

--- a/web/src/view/systemTools/index.vue
+++ b/web/src/view/systemTools/index.vue
@@ -1,9 +1,9 @@
 <template>
+  <!-- Align with routerHolder / superAdmin for Vue Router 4 nested outlets -->
   <div>
-    <keep-alive>
-      <router-view v-if="$route.meta.keepAlive"></router-view>
-    </keep-alive>
-    <router-view v-if="!$route.meta.keepAlive"></router-view>
+    <router-view v-slot="{ Component }">
+      <component :is="Component" />
+    </router-view>
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- Status filter shows placeholder「全部」instead of literal `-1`
- Restore spacing between list toolbar action buttons
- Fix systemTools nested router outlet for Vue Router 4
- Redirect parent menus to their first visible child (opens 系统配置 correctly)

## Test plan
- [x] Docker web rebuild; status select shows 全部
- [x] Rule page action buttons have gap
- [x] 系统配置 opens form at `#/layout/systemTools/system`
- [x] Parent `#/layout/systemTools` redirects to system config

Follow-up to #305.