### PR TITLE
feat(init): custom admin credentials via CLI and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,19 @@ For the usage of GShark, please refer to the [wiki](https://github.com/madneal/g
 
 # Quick start
 
-Default login after initialization:
+Default login after initialization (if not customized):
 
 ```text
 gshark / gshark
+```
+
+Set a custom admin account via script/CLI flags (no browser init page required):
+
+```bash
+./scripts/quick-docker.sh --admin-user myadmin --admin-password 'S3cret!'
+# or
+./gshark init --host 127.0.0.1 --user root --password madneal --db gshark \
+  --admin-user myadmin --admin-password 'S3cret!'
 ```
 
 ## Quick one-click deployment
@@ -38,6 +47,9 @@ Use one of the two quick deployment entries:
 ```bash
 # Option 1: Docker quick. Build and start mysql/server/web in the background.
 ./scripts/quick-docker.sh
+
+# Custom admin account
+./scripts/quick-docker.sh --admin-user myadmin --admin-password 'S3cret!'
 
 # Start the scan container too.
 ./scripts/quick-docker.sh --with-scan

--- a/README_CN.md
+++ b/README_CN.md
@@ -25,10 +25,19 @@ GShark 是一个敏感信息检测和管理平台。后端基于 Go 和 Gin 构�
 
 # 快速开始
 
-初始化后的默认登录账号：
+初始化后的默认登录账号（未自定义时）：
 
 ```text
 gshark / gshark
+```
+
+可通过脚本参数自定义管理员账号（无需打开初始化页面）：
+
+```bash
+./scripts/quick-docker.sh --admin-user myadmin --admin-password 'S3cret!'
+# 或
+./gshark init --host 127.0.0.1 --user root --password madneal --db gshark \
+  --admin-user myadmin --admin-password 'S3cret!'
 ```
 
 ## Quick 一键部署
@@ -38,6 +47,9 @@ gshark / gshark
 ```bash
 # 方式一：Docker quick，构建并后台启动 mysql/server/web
 ./scripts/quick-docker.sh
+
+# 自定义管理员账号
+./scripts/quick-docker.sh --admin-user myadmin --admin-password 'S3cret!'
 
 # 如果需要同时启动扫描容器
 ./scripts/quick-docker.sh --with-scan

--- a/scripts/quick-docker.sh
+++ b/scripts/quick-docker.sh
@@ -5,16 +5,32 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 WITH_SCAN=false
+ADMIN_USER="gshark"
+ADMIN_PASSWORD="gshark"
+# MySQL settings matching config.docker.yaml / compose
+MYSQL_HOST="177.7.0.13"
+MYSQL_PORT="3306"
+MYSQL_USER="root"
+MYSQL_PASSWORD="madneal"
+MYSQL_DB="gshark"
+SKIP_INIT=false
 
 usage() {
     cat <<'EOF'
-Usage: scripts/quick-docker.sh [--with-scan]
+Usage: scripts/quick-docker.sh [options]
 
-Build and start GShark with Docker Compose.
+Build and start GShark with Docker Compose, then initialize the database
+if needed (admin account via flags — no browser required).
 
 Options:
-  --with-scan  Also start the scanner container.
-  -h, --help   Show this help message.
+  --with-scan              Also start the scanner container.
+  --admin-user NAME        Admin login username (default: gshark).
+  --admin-password PASS    Admin login password (default: gshark).
+  --skip-init              Do not run gshark init after start.
+  -h, --help               Show this help message.
+
+Example:
+  ./scripts/quick-docker.sh --admin-user myadmin --admin-password 'S3cret!'
 EOF
 }
 
@@ -22,6 +38,19 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --with-scan)
             WITH_SCAN=true
+            ;;
+        --admin-user)
+            [[ $# -ge 2 ]] || { echo "--admin-user requires a value" >&2; exit 1; }
+            ADMIN_USER="$2"
+            shift
+            ;;
+        --admin-password)
+            [[ $# -ge 2 ]] || { echo "--admin-password requires a value" >&2; exit 1; }
+            ADMIN_PASSWORD="$2"
+            shift
+            ;;
+        --skip-init)
+            SKIP_INIT=true
             ;;
         -h|--help)
             usage
@@ -63,8 +92,37 @@ if [[ "$WITH_SCAN" == true ]]; then
     "${COMPOSE[@]}" up -d --build scan
 fi
 
+if [[ "$SKIP_INIT" != true ]]; then
+    echo "[INFO] Waiting for MySQL and server..."
+    for i in $(seq 1 60); do
+        h=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' gshark-mysql 2>/dev/null || echo missing)
+        if [[ "$h" == "healthy" ]] || [[ "$h" == "none" ]]; then
+            if docker exec gshark-server ./gshark --help >/dev/null 2>&1 || \
+               docker exec gshark-server ls ./gshark >/dev/null 2>&1; then
+                break
+            fi
+        fi
+        sleep 2
+    done
+
+    echo "[INFO] Initializing database (admin-user=${ADMIN_USER})..."
+    # Run init inside the server container so it can reach MySQL on the compose network.
+    # If already initialized, gshark init exits 0 with a skip message.
+    if ! docker exec gshark-server ./gshark init \
+        --host "$MYSQL_HOST" \
+        --port "$MYSQL_PORT" \
+        --user "$MYSQL_USER" \
+        --password "$MYSQL_PASSWORD" \
+        --db "$MYSQL_DB" \
+        --admin-user "$ADMIN_USER" \
+        --admin-password "$ADMIN_PASSWORD"; then
+        echo "[WARN] gshark init failed; you can open http://localhost:8080 and initialize in the UI," >&2
+        echo "       or re-run: docker exec gshark-server ./gshark init --help" >&2
+    fi
+fi
+
 echo
 "${COMPOSE[@]}" ps
 echo
 echo "GShark is starting at: http://localhost:8080"
-echo "Default login: gshark / gshark"
+echo "Admin login: ${ADMIN_USER} / (the password you set with --admin-password)"

--- a/scripts/quick-docker.sh
+++ b/scripts/quick-docker.sh
@@ -29,6 +29,11 @@ Options:
   --skip-init              Do not run gshark init after start.
   -h, --help               Show this help message.
 
+gshark init exit codes (used by this script):
+  0  applied successfully (server is restarted so serve reconnects)
+  2  already initialized (credentials not changed)
+  1  failure
+
 Example:
   ./scripts/quick-docker.sh --admin-user myadmin --admin-password 'S3cret!'
 EOF
@@ -92,37 +97,85 @@ if [[ "$WITH_SCAN" == true ]]; then
     "${COMPOSE[@]}" up -d --build scan
 fi
 
-if [[ "$SKIP_INIT" != true ]]; then
-    echo "[INFO] Waiting for MySQL and server..."
+INIT_RESULT="skipped" # skipped | applied | failed | skipped_flag
+
+if [[ "$SKIP_INIT" == true ]]; then
+    INIT_RESULT="skipped_flag"
+else
+    echo "[INFO] Waiting for MySQL healthy and server binary..."
+    ready=false
     for i in $(seq 1 60); do
         h=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' gshark-mysql 2>/dev/null || echo missing)
-        if [[ "$h" == "healthy" ]] || [[ "$h" == "none" ]]; then
-            if docker exec gshark-server ./gshark --help >/dev/null 2>&1 || \
-               docker exec gshark-server ls ./gshark >/dev/null 2>&1; then
+        if [[ "$h" == "healthy" ]]; then
+            if docker exec gshark-server test -x ./gshark 2>/dev/null; then
+                ready=true
                 break
             fi
         fi
         sleep 2
     done
+    if [[ "$ready" != true ]]; then
+        echo "[ERROR] Timed out waiting for MySQL healthy / gshark-server binary." >&2
+        exit 1
+    fi
 
     echo "[INFO] Initializing database (admin-user=${ADMIN_USER})..."
-    # Run init inside the server container so it can reach MySQL on the compose network.
-    # If already initialized, gshark init exits 0 with a skip message.
-    if ! docker exec gshark-server ./gshark init \
+    # Separate process from long-lived serve: on success we must restart server
+    # so GVA_DB reconnects (otherwise NeedInit blocks login).
+    set +e
+    docker exec gshark-server ./gshark init \
         --host "$MYSQL_HOST" \
         --port "$MYSQL_PORT" \
         --user "$MYSQL_USER" \
         --password "$MYSQL_PASSWORD" \
         --db "$MYSQL_DB" \
         --admin-user "$ADMIN_USER" \
-        --admin-password "$ADMIN_PASSWORD"; then
-        echo "[WARN] gshark init failed; you can open http://localhost:8080 and initialize in the UI," >&2
-        echo "       or re-run: docker exec gshark-server ./gshark init --help" >&2
-    fi
+        --admin-password "$ADMIN_PASSWORD"
+    init_rc=$?
+    set -e
+
+    case "$init_rc" in
+        0)
+            INIT_RESULT="applied"
+            echo "[INFO] Init applied; restarting server so it reconnects to MySQL..."
+            "${COMPOSE[@]}" restart server
+            # wait for server to accept traffic again
+            for i in $(seq 1 30); do
+                if curl -sS -o /dev/null -w '' -X POST "http://localhost:8888/init/checkdb" 2>/dev/null; then
+                    break
+                fi
+                sleep 1
+            done
+            ;;
+        2)
+            INIT_RESULT="skipped"
+            echo "[INFO] Database already initialized; admin credentials were not changed."
+            ;;
+        *)
+            INIT_RESULT="failed"
+            echo "[ERROR] gshark init failed (exit ${init_rc})." >&2
+            echo "        Open http://localhost:8080 to initialize in the UI, or re-run:" >&2
+            echo "        docker exec gshark-server ./gshark init --help" >&2
+            ;;
+    esac
 fi
 
 echo
 "${COMPOSE[@]}" ps
 echo
 echo "GShark is starting at: http://localhost:8080"
-echo "Admin login: ${ADMIN_USER} / (the password you set with --admin-password)"
+case "$INIT_RESULT" in
+    applied)
+        echo "Admin login: ${ADMIN_USER} / (password from --admin-password)"
+        ;;
+    skipped)
+        echo "Admin login: unchanged (DB was already initialized; --admin-user/--admin-password ignored)"
+        ;;
+    skipped_flag)
+        echo "Admin login: not initialized by this script (--skip-init)"
+        ;;
+    failed)
+        echo "Admin login: unknown (init failed — do not assume credentials above were applied)"
+        exit 1
+        ;;
+esac

--- a/scripts/quick-release.sh
+++ b/scripts/quick-release.sh
@@ -235,6 +235,7 @@ if [[ "$SKIP_INIT" != true ]]; then
     [[ "$mysql_host" == "$mysql_port" ]] && mysql_port="3306"
 
     echo "[INFO] Initializing database (admin-user=${ADMIN_USER})..."
+    set +e
     (
         cd "$APP_DIR"
         ./gshark init \
@@ -244,8 +245,30 @@ if [[ "$SKIP_INIT" != true ]]; then
             --password "$mysql_password" \
             --db "$mysql_db" \
             --admin-user "$ADMIN_USER" \
-            --admin-password "$ADMIN_PASSWORD" || true
+            --admin-password "$ADMIN_PASSWORD"
     )
+    init_rc=$?
+    set -e
+    case "$init_rc" in
+        0)
+            INIT_RESULT="applied"
+            echo "[INFO] Init applied successfully."
+            ;;
+        2)
+            INIT_RESULT="skipped"
+            echo "[INFO] Database already initialized; admin credentials were not changed."
+            ;;
+        *)
+            INIT_RESULT="failed"
+            echo "[ERROR] gshark init failed (exit ${init_rc})." >&2
+            if ! "$APP_DIR/gshark" init --help >/dev/null 2>&1; then
+                echo "        This release binary may not include 'gshark init'." >&2
+            fi
+            echo "        Fix MySQL/config or run init manually before relying on login." >&2
+            ;;
+    esac
+else
+    INIT_RESULT="skipped_flag"
 fi
 
 (
@@ -258,6 +281,23 @@ PID="$(cat "$APP_DIR/gshark.pid")"
 
 echo
 echo "GShark is starting at: http://localhost:$FRONTEND_PORT"
-echo "Admin login: ${ADMIN_USER} / (the password you set with --admin-password)"
+case "${INIT_RESULT:-unknown}" in
+    applied)
+        echo "Admin login: ${ADMIN_USER} / (password from --admin-password)"
+        ;;
+    skipped)
+        echo "Admin login: unchanged (DB was already initialized; flags ignored)"
+        ;;
+    skipped_flag)
+        echo "Admin login: not initialized by this script (--skip-init)"
+        ;;
+    failed)
+        echo "Admin login: unknown (init failed — credentials may not match flags)"
+        exit 1
+        ;;
+    *)
+        echo "Admin login: unknown"
+        ;;
+esac
 echo "Backend PID: $PID"
 echo "Backend log: $APP_DIR/gshark.log"

--- a/scripts/quick-release.sh
+++ b/scripts/quick-release.sh
@@ -6,16 +6,22 @@ WORK_DIR="${GSHARK_WORK_DIR:-/tmp/gshark-quick-release}"
 FRONTEND_PORT="${GSHARK_FRONTEND_PORT:-8080}"
 BACKEND_PORT="${GSHARK_BACKEND_PORT:-8888}"
 ZIP_FILE=""
+ADMIN_USER="gshark"
+ADMIN_PASSWORD="gshark"
+SKIP_INIT=false
 
 usage() {
     cat <<'EOF'
-Usage: scripts/quick-release.sh [--file PATH]
+Usage: scripts/quick-release.sh [options]
 
 Download a GShark release package, deploy dist/ to Nginx, and start the backend.
 
 Options:
-  --file PATH  Use a local release zip instead of downloading the latest release.
-  -h, --help   Show this help message.
+  --file PATH              Use a local release zip instead of downloading the latest release.
+  --admin-user NAME        Admin login username (default: gshark).
+  --admin-password PASS    Admin login password (default: gshark).
+  --skip-init              Do not run gshark init before serve.
+  -h, --help               Show this help message.
 
 Environment:
   GSHARK_FRONTEND_PORT  Frontend port. Default: 8080
@@ -34,6 +40,19 @@ while [[ $# -gt 0 ]]; do
             }
             ZIP_FILE="$2"
             shift
+            ;;
+        --admin-user)
+            [[ $# -ge 2 ]] || { echo "--admin-user requires a value" >&2; exit 1; }
+            ADMIN_USER="$2"
+            shift
+            ;;
+        --admin-password)
+            [[ $# -ge 2 ]] || { echo "--admin-password requires a value" >&2; exit 1; }
+            ADMIN_PASSWORD="$2"
+            shift
+            ;;
+        --skip-init)
+            SKIP_INIT=true
             ;;
         -h|--help)
             usage
@@ -194,6 +213,41 @@ if command -v lsof >/dev/null 2>&1; then
 fi
 
 chmod +x "$APP_DIR/gshark"
+
+if [[ "$SKIP_INIT" != true ]]; then
+    # Read MySQL settings from config.yaml if present (path: host:port)
+    mysql_path="127.0.0.1:3306"
+    mysql_user="root"
+    mysql_password=""
+    mysql_db="gshark"
+    cfg="$APP_DIR/config.yaml"
+    if [[ -f "$cfg" ]]; then
+        mysql_path="$(awk '/^mysql:/{f=1} f&&/path:/{print $2; exit}' "$cfg" | tr -d '"' || true)"
+        mysql_user="$(awk '/^mysql:/{f=1} f&&/username:/{print $2; exit}' "$cfg" | tr -d '"' || true)"
+        mysql_password="$(awk '/^mysql:/{f=1} f&&/password:/{print $2; exit}' "$cfg" | tr -d '"' || true)"
+        mysql_db="$(awk '/^mysql:/{f=1} f&&/db-name:/{print $2; exit}' "$cfg" | tr -d '"' || true)"
+        [[ -n "$mysql_path" ]] || mysql_path="127.0.0.1:3306"
+        [[ -n "$mysql_user" ]] || mysql_user="root"
+        [[ -n "$mysql_db" ]] || mysql_db="gshark"
+    fi
+    mysql_host="${mysql_path%%:*}"
+    mysql_port="${mysql_path##*:}"
+    [[ "$mysql_host" == "$mysql_port" ]] && mysql_port="3306"
+
+    echo "[INFO] Initializing database (admin-user=${ADMIN_USER})..."
+    (
+        cd "$APP_DIR"
+        ./gshark init \
+            --host "$mysql_host" \
+            --port "$mysql_port" \
+            --user "$mysql_user" \
+            --password "$mysql_password" \
+            --db "$mysql_db" \
+            --admin-user "$ADMIN_USER" \
+            --admin-password "$ADMIN_PASSWORD" || true
+    )
+fi
+
 (
     cd "$APP_DIR"
     ./gshark serve > gshark.log 2>&1 &
@@ -204,6 +258,6 @@ PID="$(cat "$APP_DIR/gshark.pid")"
 
 echo
 echo "GShark is starting at: http://localhost:$FRONTEND_PORT"
-echo "Default login: gshark / gshark"
+echo "Admin login: ${ADMIN_USER} / (the password you set with --admin-password)"
 echo "Backend PID: $PID"
 echo "Backend log: $APP_DIR/gshark.log"

--- a/server/main.go
+++ b/server/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/madneal/gshark/model/request"
 	"github.com/madneal/gshark/search"
 	"github.com/madneal/gshark/service"
+	"github.com/madneal/gshark/source"
 	"github.com/spf13/cobra"
 )
 
@@ -58,17 +59,23 @@ func main() {
 		initAdminUser     string
 		initAdminPassword string
 	)
+	// Exit codes for scripts: 0 = applied, 2 = already initialized (skip), 1 = error.
 	initCmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialize database and seed admin user",
-		Long:  "Create database, run migrations, seed data. Admin credentials via --admin-user / --admin-password (default gshark/gshark).",
+		Long: `Create database, run migrations, seed data. Admin credentials via --admin-user / --admin-password (default gshark/gshark).
+
+Exit codes:
+  0  initialization applied successfully
+  1  failure
+  2  already initialized (skipped; credentials not changed)`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if global.GVA_DB != nil {
 				// Already connected — treat as already initialized unless empty.
 				var n int64
 				if err := global.GVA_DB.Table("sys_users").Count(&n).Error; err == nil && n > 0 {
-					color.Warn.Println("database already initialized (sys_users not empty); skip")
-					return
+					color.Warn.Println("INIT_SKIP: database already initialized (sys_users not empty); credentials not changed")
+					os.Exit(2)
 				}
 			}
 			conf := request.InitDB{
@@ -84,11 +91,17 @@ func main() {
 				color.Error.Printf("init failed: %v\n", err)
 				os.Exit(1)
 			}
+			// InitDB can succeed while the admin seed is skipped (DB already had
+			// users, e.g. config.yaml was stale so the early check above missed it).
+			if !source.AdminSeedApplied {
+				color.Warn.Println("INIT_SKIP: database already initialized (admin seed skipped); credentials not changed")
+				os.Exit(2)
+			}
 			adminUser := initAdminUser
 			if adminUser == "" {
 				adminUser = "gshark"
 			}
-			color.Success.Println("database initialized successfully")
+			color.Success.Println("INIT_OK: database initialized successfully")
 			fmt.Printf("admin login: %s / (your --admin-password)\n", adminUser)
 		},
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/gookit/color"
 	"github.com/madneal/gshark/core"
 	"github.com/madneal/gshark/global"
 	"github.com/madneal/gshark/initialize"
+	"github.com/madneal/gshark/model/request"
 	"github.com/madneal/gshark/search"
+	"github.com/madneal/gshark/service"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 func init() {
@@ -27,6 +31,7 @@ func main() {
 	var configFile string
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "config.yaml",
 		"config file")
+
 	serveCmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Start the GShark server",
@@ -43,20 +48,63 @@ func main() {
 			search.ScanTask()
 		},
 	}
+
+	var (
+		initHost          string
+		initPort          string
+		initUser          string
+		initPassword      string
+		initDBName        string
+		initAdminUser     string
+		initAdminPassword string
+	)
+	initCmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialize database and seed admin user",
+		Long:  "Create database, run migrations, seed data. Admin credentials via --admin-user / --admin-password (default gshark/gshark).",
+		Run: func(cmd *cobra.Command, args []string) {
+			if global.GVA_DB != nil {
+				// Already connected — treat as already initialized unless empty.
+				var n int64
+				if err := global.GVA_DB.Table("sys_users").Count(&n).Error; err == nil && n > 0 {
+					color.Warn.Println("database already initialized (sys_users not empty); skip")
+					return
+				}
+			}
+			conf := request.InitDB{
+				Host:          initHost,
+				Port:          initPort,
+				UserName:      initUser,
+				Password:      initPassword,
+				DBName:        initDBName,
+				AdminUserName: initAdminUser,
+				AdminPassword: initAdminPassword,
+			}
+			if err := service.InitDB(conf); err != nil {
+				color.Error.Printf("init failed: %v\n", err)
+				os.Exit(1)
+			}
+			adminUser := initAdminUser
+			if adminUser == "" {
+				adminUser = "gshark"
+			}
+			color.Success.Println("database initialized successfully")
+			fmt.Printf("admin login: %s / (your --admin-password)\n", adminUser)
+		},
+	}
+	initCmd.Flags().StringVar(&initHost, "host", "127.0.0.1", "MySQL host")
+	initCmd.Flags().StringVar(&initPort, "port", "3306", "MySQL port")
+	initCmd.Flags().StringVar(&initUser, "user", "root", "MySQL username")
+	initCmd.Flags().StringVar(&initPassword, "password", "", "MySQL password")
+	initCmd.Flags().StringVar(&initDBName, "db", "gshark", "MySQL database name")
+	initCmd.Flags().StringVar(&initAdminUser, "admin-user", "gshark", "Admin login username")
+	initCmd.Flags().StringVar(&initAdminPassword, "admin-password", "gshark", "Admin login password (plain)")
+
 	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(scanCmd)
+	rootCmd.AddCommand(initCmd)
 	if err := rootCmd.Execute(); err != nil {
 		color.Println(err)
 		os.Exit(1)
 	}
-	//if global.GVA_DB != nil {
-	//	service.InitDB(request.InitDB{
-	//		Host: global.GVA_CONFIG.Mysql.Path,
-	//	})
-	//	db, _ := global.GVA_DB.DB()
-	//	defer db.Close()
-	//} else {
-	//	color.Danger.Println("数据库连接失败，请确定在 config.yaml 配置正确数据库信息")
-	//}
-
 }

--- a/server/model/request/sys_init.go
+++ b/server/model/request/sys_init.go
@@ -6,4 +6,7 @@ type InitDB struct {
 	UserName string `json:"userName" binding:"required"`
 	Password string `json:"password"`
 	DBName   string `json:"dbName" binding:"required"`
+	// Admin login credentials (plain password; server stores MD5). Empty → gshark/gshark.
+	AdminUserName string `json:"adminUserName"`
+	AdminPassword string `json:"adminPassword"`
 }

--- a/server/service/sys_initdb.go
+++ b/server/service/sys_initdb.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/madneal/gshark/config"
@@ -69,6 +70,12 @@ func InitDB(conf request.InitDB) error {
 	}
 	if conf.AdminPassword == "" {
 		conf.AdminPassword = "gshark"
+	}
+	if len(conf.AdminUserName) == 0 {
+		return errors.New("admin username is required")
+	}
+	if len(conf.AdminPassword) < 6 {
+		return errors.New("admin password must be at least 6 characters")
 	}
 	source.SetAdminCredentials(conf.AdminUserName, conf.AdminPassword)
 

--- a/server/service/sys_initdb.go
+++ b/server/service/sys_initdb.go
@@ -63,6 +63,15 @@ func InitDB(conf request.InitDB) error {
 	if conf.Port == "" {
 		conf.Port = "3306"
 	}
+	// Admin login (distinct from MySQL UserName/Password)
+	if conf.AdminUserName == "" {
+		conf.AdminUserName = "gshark"
+	}
+	if conf.AdminPassword == "" {
+		conf.AdminPassword = "gshark"
+	}
+	source.SetAdminCredentials(conf.AdminUserName, conf.AdminPassword)
+
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/", conf.UserName, conf.Password, conf.Host, conf.Port)
 	createSql := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_general_ci;", conf.DBName)
 	if err := executeSql(dsn, "mysql", createSql); err != nil {

--- a/server/source/admin.go
+++ b/server/source/admin.go
@@ -1,11 +1,12 @@
 package source
 
 import (
+	"time"
+
 	"github.com/gookit/color"
 	"github.com/madneal/gshark/global"
 	"github.com/madneal/gshark/model"
-	"time"
-
+	"github.com/madneal/gshark/utils"
 	uuid "github.com/satori/go.uuid"
 	"gorm.io/gorm"
 )
@@ -14,22 +15,43 @@ var Admin = new(admin)
 
 type admin struct{}
 
-var admins = []model.SysUser{
-	{GVA_MODEL: global.GVA_MODEL{CreatedAt: time.Now(), UpdatedAt: time.Now()}, UUID: uuid.NewV4(), Username: "gshark",
-		Password: "4e097ce13bea7674b8d828b63e4f7b8c", NickName: "超级管理员",
-		HeaderImg: "https://s2.loli.net/2023/12/29/FRNA23eJcXjDM4Y.jpg", AuthorityId: "888"},
+// Defaults used when init does not pass custom credentials.
+var (
+	AdminUsername = "gshark"
+	AdminPassword = "gshark" // plain text; hashed in Init
+	AdminNickName = "超级管理员"
+)
+
+// SetAdminCredentials sets the admin seed account for Init().
+// Empty values keep the previous/default value.
+func SetAdminCredentials(username, password string) {
+	if username != "" {
+		AdminUsername = username
+	}
+	if password != "" {
+		AdminPassword = password
+	}
 }
 
 func (a *admin) Init() error {
+	user := model.SysUser{
+		GVA_MODEL:   global.GVA_MODEL{CreatedAt: time.Now(), UpdatedAt: time.Now()},
+		UUID:        uuid.NewV4(),
+		Username:    AdminUsername,
+		Password:    utils.MD5V([]byte(AdminPassword)),
+		NickName:    AdminNickName,
+		HeaderImg:   "https://s2.loli.net/2023/12/29/FRNA23eJcXjDM4Y.jpg",
+		AuthorityId: "888",
+	}
 	return global.GVA_DB.Transaction(func(tx *gorm.DB) error {
 		if tx.Where("id IN ?", []int{1, 2}).Find(&[]model.SysUser{}).RowsAffected == 2 {
 			color.Danger.Println("\n[Mysql] --> sys_users 表的初始数据已存在!")
 			return nil
 		}
-		if err := tx.Create(&admins).Error; err != nil { // 遇到错误时回滚事务
+		if err := tx.Create(&user).Error; err != nil {
 			return err
 		}
-		color.Info.Println("\n[Mysql] --> sys_users 表初始数据成功!")
+		color.Info.Printf("\n[Mysql] --> sys_users 初始管理员: %s\n", AdminUsername)
 		return nil
 	})
 }

--- a/server/source/admin.go
+++ b/server/source/admin.go
@@ -22,6 +22,10 @@ var (
 	AdminNickName = "超级管理员"
 )
 
+// AdminSeedApplied reports whether the last Init() actually created the admin
+// user (false when seeding was skipped because sys_users already had rows).
+var AdminSeedApplied bool
+
 // SetAdminCredentials sets the admin seed account for Init().
 // Empty values keep the previous/default value.
 func SetAdminCredentials(username, password string) {
@@ -43,14 +47,21 @@ func (a *admin) Init() error {
 		HeaderImg:   "https://s2.loli.net/2023/12/29/FRNA23eJcXjDM4Y.jpg",
 		AuthorityId: "888",
 	}
+	AdminSeedApplied = false
 	return global.GVA_DB.Transaction(func(tx *gorm.DB) error {
-		if tx.Where("id IN ?", []int{1, 2}).Find(&[]model.SysUser{}).RowsAffected == 2 {
+		// Only one admin is seeded; skip if any user already exists (idempotent).
+		var n int64
+		if err := tx.Model(&model.SysUser{}).Count(&n).Error; err != nil {
+			return err
+		}
+		if n > 0 {
 			color.Danger.Println("\n[Mysql] --> sys_users 表的初始数据已存在!")
 			return nil
 		}
 		if err := tx.Create(&user).Error; err != nil {
 			return err
 		}
+		AdminSeedApplied = true
 		color.Info.Printf("\n[Mysql] --> sys_users 初始管理员: %s\n", AdminUsername)
 		return nil
 	})

--- a/web/src/view/init/init.vue
+++ b/web/src/view/init/init.vue
@@ -29,6 +29,20 @@
         <el-form-item label="dbName">
           <el-input v-model="form.dbName" placeholder="请输入数据库名称" />
         </el-form-item>
+        <el-form-item label="管理员用户名">
+          <el-input
+            v-model="form.adminUserName"
+            placeholder="登录用户名（默认 gshark）"
+          />
+        </el-form-item>
+        <el-form-item label="管理员密码">
+          <el-input
+            v-model="form.adminPassword"
+            type="password"
+            show-password
+            placeholder="登录密码（默认 gshark）"
+          />
+        </el-form-item>
         <el-form-item>
           <div style="text-align: right">
             <el-button type="primary" @click="onSubmit">立即初始化</el-button>
@@ -52,11 +66,21 @@ export default {
         userName: "root",
         password: "",
         dbName: "gshark",
+        adminUserName: "gshark",
+        adminPassword: "gshark",
       },
     };
   },
   methods: {
     async onSubmit() {
+      if (!this.form.adminUserName || !this.form.adminPassword) {
+        this.$message({ type: "warning", message: "请填写管理员用户名和密码" });
+        return;
+      }
+      if (this.form.adminPassword.length < 6) {
+        this.$message({ type: "warning", message: "管理员密码至少 6 位" });
+        return;
+      }
       const loading = this.$loading({
         lock: true,
         text: "正在初始化数据库，请稍候",
@@ -65,7 +89,10 @@ export default {
       try {
         const res = await initDB(this.form);
         if (res.code == 0) {
-          this.$message({ type: "success", message: res.msg });
+          this.$message({
+            type: "success",
+            message: `初始化成功，请使用 ${this.form.adminUserName} 登录`,
+          });
           this.$router.push({ name: "login" });
         }
       } finally {

--- a/web/src/view/init/init.vue
+++ b/web/src/view/init/init.vue
@@ -40,7 +40,7 @@
             v-model="form.adminPassword"
             type="password"
             show-password
-            placeholder="登录密码（默认 gshark）"
+            placeholder="请输入登录密码（至少 6 位）"
           />
         </el-form-item>
         <el-form-item>
@@ -67,7 +67,7 @@ export default {
         password: "",
         dbName: "gshark",
         adminUserName: "gshark",
-        adminPassword: "gshark",
+        adminPassword: "",
       },
     };
   },


### PR DESCRIPTION
## Summary

- Seed the first admin from parameters instead of hard-coded `gshark`/`gshark` only
- New CLI: `gshark init --admin-user ... --admin-password ...` (plus MySQL flags)
- `quick-docker.sh` / `quick-release.sh` accept `--admin-user` / `--admin-password` and auto-run init when needed
- Init page optional fields for the same API body; empty values still default to `gshark`/`gshark`

## Usage

```bash
./gshark init --host 127.0.0.1 --user root --password madneal --db gshark \
  --admin-user myadmin --admin-password 'S3cret!'

./scripts/quick-docker.sh --admin-user myadmin --admin-password 'S3cret!'
```

## Test plan

- [ ] `gshark init --help` shows admin flags
- [ ] Fresh DB with custom admin → login works; default gshark fails
- [ ] Omit admin flags → still seeds gshark/gshark
- [ ] Already initialized → init skips/fails cleanly without wiping users
- [ ] Web init form submits `adminUserName` / `adminPassword`