### PR TITLE
test(postman): make integration task opt-in

### DIFF
--- a/server/search/postman/search_test.go
+++ b/server/search/postman/search_test.go
@@ -4,12 +4,16 @@ import (
 	"fmt"
 	"github.com/madneal/gshark/global"
 	"github.com/madneal/gshark/initialize"
+	"os"
 	"testing"
 )
 
 func TestRunTask(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
+	}
+	if os.Getenv("RUN_POSTMAN_INTEGRATION") != "1" {
+		t.Skip("set RUN_POSTMAN_INTEGRATION=1 to run the Postman integration test")
 	}
 	InitialDataBase()
 	if global.GVA_DB == nil {


### PR DESCRIPTION
## Summary

- require RUN_POSTMAN_INTEGRATION=1 before running TestRunTask
- keep short-mode skipping and production RunTask behavior unchanged
- prevent default test runs from entering the 15-minute Postman task delay

## Verification

- GO111MODULE=on go test ./search/postman -run '^TestRunTask$' -count=1 -v
- GO111MODULE=on go test -short ./...