### PR TITLE
fix(scanner): handle empty GitHub configuration

### DIFF
--- a/server/search/githubsearch/gitclient.go
+++ b/server/search/githubsearch/gitclient.go
@@ -39,6 +39,9 @@ func GetGithubClient() (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(tokens) == 0 {
+		return nil, errors.New("github client initialization failed: no token configured")
+	}
 	client := InitClient(tokens[0].Content)
 	if client == nil {
 		err = errors.New("github Client initial failed, please add token")

--- a/server/search/githubsearch/search.go
+++ b/server/search/githubsearch/search.go
@@ -19,6 +19,9 @@ import (
 )
 
 func Search(rules []model.Rule) {
+	if len(rules) == 0 {
+		return
+	}
 	client, err := GetGithubClient()
 	if err != nil {
 		global.GVA_LOG.Error("GetGithubClient err", zap.Error(err))

--- a/server/search/githubsearch/search_test.go
+++ b/server/search/githubsearch/search_test.go
@@ -20,3 +20,7 @@ func TestSearch(t *testing.T) {
 	})
 	Search(rules)
 }
+
+func TestSearchWithNoRules(t *testing.T) {
+	Search(nil)
+}


### PR DESCRIPTION
## Summary

- skip GitHub client initialization when no enabled GitHub rules exist
- return a descriptive error when GitHub tokens are empty instead of indexing `tokens[0]`
- add a regression test for an empty GitHub rule list

This prevents the scanner container from entering a panic/restart loop and allows later providers, including Postman, to run.

Closes #315

## Testing

- `GO111MODULE=on go test ./search/githubsearch`
- `GO111MODULE=on go test ./search/...` *(GitHub scanner tests pass; the existing Postman integration test `TestClient_SearchAPI` fails with a nil response when its external request is unavailable.)*
