### PR TITLE
refactor(search): remove secondary keyword filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ For the Github or Gitlab rule, the rule will be matched by the syntax in the cor
 
 ### Filter Configuration
 
-Filter is only addressed to GitHub search now. There are three classes of filters, including `extension`, `keyword`, `sec_keyword`. For `extension` and `keyword`, they can used for blacklist or whitelist.
+Filters currently apply only to GitHub search. The supported classes are `extension` and `keyword`, and both can be configured as a blacklist or whitelist.
 
 For more information, you can refer to this [video](https://www.bilibili.com/video/BV1aG4y1c72N/?vd_source=ef4657ebf0549af8755f75118b6e81bb).
 
@@ -342,7 +342,7 @@ One rule should normally contain one search expression. Use batch import for mul
 
 11. How can I reduce noisy results from `.json`, `.csv`, log files, and similar files?
 
-Use filters. Filters are focused on GitHub search and support types such as `extension`, `keyword`, and `sec_keyword`. Extension filtering happens before results are stored. Secondary filtering uses secondary keywords to refine results; it is not the same feature as extension filtering.
+Use GitHub filters such as `extension` and `keyword` to narrow the initial search and reduce noisy results before they are stored.
 
 12. How should GitHub rate limits be handled?
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -266,7 +266,7 @@ npm run serve
 
 ### 过滤器配置
 
-过滤器目前仅针对 GitHub 搜索。有三类过滤器，包括 `extension`、`keyword`、`sec_keyword`。对于 `extension` 和 `keyword`，它们可以用于黑名单或白名单。
+过滤器目前仅针对 GitHub 搜索，支持 `extension` 和 `keyword` 两类，两者都可以配置为黑名单或白名单。
 
 更多信息，您可以参考这个[视频](https://www.bilibili.com/video/BV1aG4y1c72N/?vd_source=ef4657ebf0549af8755f75118b6e81bb)。
 
@@ -310,7 +310,7 @@ scanner 依赖数据库初始化。MySQL 初始化前 scanner 容器可能会退
 
 6. GShark 的核心运行链路是什么？
 
-基本链路是：配置数据库 -> 初始化系统 -> 登录后台 -> 添加 token -> 添加规则 -> 启动 scan 服务 -> 拉取搜索结果 -> 过滤/二次过滤 -> 人工确认或忽略 -> 导出结果。
+基本链路是：配置数据库 -> 初始化系统 -> 登录后台 -> 添加 token -> 添加规则 -> 启动 scan 服务 -> 拉取并过滤搜索结果 -> 人工确认或忽略 -> 导出结果。
 
 7. 配置 token 和规则后为什么没有扫描结果？
 
@@ -339,7 +339,7 @@ api_key extension:yaml
 
 11. 如何减少 `.json`、`.csv`、日志文件等噪声结果？
 
-使用过滤器。过滤器面向 GitHub 搜索，支持 `extension`、`keyword`、`sec_keyword` 等类型。后缀过滤是在结果入库前过滤；二次过滤是基于二级关键词进一步筛结果，两者不是同一个能力。
+使用 GitHub 过滤器，通过 `extension` 和 `keyword` 缩小初始搜索范围，在结果入库前减少噪声。
 
 12. GitHub rate limit 怎么处理？
 

--- a/server/api/search_result.go
+++ b/server/api/search_result.go
@@ -3,13 +3,11 @@ package api
 import (
 	"encoding/csv"
 	"encoding/json"
-	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/madneal/gshark/global"
 	"github.com/madneal/gshark/model"
 	"github.com/madneal/gshark/model/request"
 	"github.com/madneal/gshark/model/response"
-	"github.com/madneal/gshark/search/githubsearch"
 	"github.com/madneal/gshark/service"
 	"go.uber.org/zap"
 	"net/http"
@@ -17,7 +15,6 @@ import (
 	"strings"
 )
 
-var taskStatus = "stop"
 var statusOptions = map[int]string{
 	0: "未处理", // Unprocessed
 	1: "已处理", // Processed
@@ -54,10 +51,6 @@ func UpdateSearchResultByIds(c *gin.Context) {
 		return
 	}
 	respondMutation(c, service.UpdateSearchResultByIds(batchUpdateReq), "批量更新状态失败！", "批量更新状态失败", "批量更新状态成功")
-}
-
-func GetTaskStatus(c *gin.Context) {
-	response.OkWithMessage(taskStatus, c)
 }
 
 func StartAITask(c *gin.Context) {
@@ -106,65 +99,6 @@ func StartAITask(c *gin.Context) {
 	}()
 }
 
-func StartSecFilterTask(c *gin.Context) {
-	response.Ok(c)
-	go func(taskStatus *string) {
-		*taskStatus = "running"
-		client, err := githubsearch.GetGithubClient()
-		if err != nil {
-			*taskStatus = "failed"
-			global.GVA_LOG.Error("GetGithubClient error", zap.Error(err))
-			response.FailWithMessage("初始化 github 客户端失败", c)
-			return
-		}
-		err, repos := service.GetReposByStatus(0)
-		if err != nil {
-			*taskStatus = "failed"
-			global.GVA_LOG.Error("GetReposByStatus error", zap.Error(err))
-			return
-		}
-		err, secKeywordFilters := model.GetFilterByClass("sec_keyword")
-		if err != nil {
-			*taskStatus = "failed"
-			global.GVA_LOG.Error("GetFilterByClass sec_keyword error", zap.Error(err))
-			return
-		}
-		var secKeywords []string
-		for _, secKeywordFilter := range secKeywordFilters {
-			secKeywords = append(secKeywords, strings.Split(secKeywordFilter.Content, ",")...)
-		}
-		for _, repo := range repos {
-			for _, keyword := range secKeywords {
-				query := fmt.Sprintf("repo:%s %s ", repo, keyword)
-				results, err := client.SearchCode(query)
-				// find results after second filter, then ignore the results by repo
-				if len(results) > 0 && *results[0].Total > 0 {
-					err = service.IgnoreResultsByRepo(repo)
-					if err != nil {
-						global.GVA_LOG.Error("IgnoreResultsByRepo error", zap.Error(err))
-						continue
-					}
-				}
-				originalKeyword, err := service.GetKeywordByRepo(repo)
-				if err != nil {
-					global.GVA_LOG.Error("GetKeywordByRepo error", zap.Error(err))
-					continue
-				}
-				if err != nil {
-					global.GVA_LOG.Error("Github search code error", zap.Error(err))
-					continue
-				}
-				if results != nil && len(results) > 0 && *results[0].Total > 0 {
-					githubsearch.SaveResult(results, originalKeyword, keyword)
-				}
-			}
-
-		}
-		*taskStatus = "done"
-	}(&taskStatus)
-
-}
-
 func UpdateSearchResult(c *gin.Context) {
 	var updateReq request.UpdateReq
 	if !bindJSON(c, &updateReq) {
@@ -204,7 +138,7 @@ func ExportSearchResult(c *gin.Context) {
 	c.Header("Content-Type", "text/csv")
 	c.Header("Content-Disposition", `attachment; filename="search_results.csv"`)
 	writer := csv.NewWriter(c.Writer)
-	headers := []string{"Repo", "RepoUrl", "Matches", "Keyword", "SecKeyword", "Path",
+	headers := []string{"Repo", "RepoUrl", "Matches", "Keyword", "Path",
 		"Url", "Status"}
 	if err := writer.Write(headers); err != nil {
 		response.FailWithMessage("导出失败", c)
@@ -223,7 +157,6 @@ func ExportSearchResult(c *gin.Context) {
 			result.RepoUrl,
 			result.Matches,
 			result.Keyword,
-			result.SecKeyword,
 			result.Path,
 			result.Url,
 			statusOptions[result.Status],

--- a/server/model/request/searchResult.go
+++ b/server/model/request/searchResult.go
@@ -6,8 +6,7 @@ type SearchResultSearch struct {
 }
 
 type SearchInfo struct {
-	Status         int    `json:"status" form:"status"`
-	Keyword        string `json:"keyword" form:"keyword"`
-	Query          string `json:"query" form:"query"`
-	OnlySecKeyword bool   `json:"onlySecKeyword" form:"onlySecKeyword"`
+	Status  int    `json:"status" form:"status"`
+	Keyword string `json:"keyword" form:"keyword"`
+	Query   string `json:"query" form:"query"`
 }

--- a/server/model/search_result.go
+++ b/server/model/search_result.go
@@ -14,7 +14,6 @@ type SearchResult struct {
 	RepoUrl         string         `gorm:"column:repository;type:varchar(200);"`
 	Matches         string         `json:"matches" form:"matches" gorm:"column:matches;comment:;type:text;"`
 	Keyword         string         `json:"keyword" form:"keyword" gorm:"column:keyword;comment:;type:varchar(100);size:100;"`
-	SecKeyword      string         `json:"sec_keyword" form:"sec_keyword" gorm:"column:sec_keyword;comment:;type:varchar(100);size:100;"`
 	Path            string         `json:"path" form:"path" gorm:"column:path;comment:;type:varchar(500);size:100;"`
 	Url             string         `json:"url" form:"url" gorm:"column:url;comment:;type:varchar(500);size:500;"`
 	Status          int            `json:"status" form:"status" gorm:"column:status;comment:;type:int;size:3;"`

--- a/server/router/search_result.go
+++ b/server/router/search_result.go
@@ -17,8 +17,6 @@ func InitSearchResultRouter(Router *gin.RouterGroup) {
 		SearchResultRouter.GET("getSearchResultList", api.GetSearchResultList)
 		SearchResultRouter.GET("exportSearchResult", api.ExportSearchResult)
 		SearchResultRouter.POST("updateSearchResultStatusByIds", api.UpdateSearchResultByIds)
-		SearchResultRouter.POST("startSecFilterTask", api.StartSecFilterTask)
-		SearchResultRouter.GET("getTaskStatus", api.GetTaskStatus)
 		SearchResultRouter.POST("startAITask", api.StartAITask)
 	}
 }

--- a/server/search/githubsearch/search.go
+++ b/server/search/githubsearch/search.go
@@ -39,7 +39,7 @@ func Search(rules []model.Rule) {
 			global.GVA_LOG.Error("SearchCode error", zap.Error(err))
 			continue
 		}
-		stats := SaveResultWithStats(results, rule.Content, "")
+		stats := SaveResultWithStats(results, rule.Content)
 		global.GVA_LOG.Info(stats.Summary(rule.Content, "GitHub"))
 		if stats.Inserted > 0 {
 			repoInfo := ""
@@ -70,29 +70,23 @@ func Search(rules []model.Rule) {
 	}
 }
 
-func SaveResult(results []*github.CodeSearchResult, keyword, secKeyword string) int {
-	stats := SaveResultWithStats(results, keyword, secKeyword)
-	return stats.Inserted
-}
-
-func SaveResultWithStats(results []*github.CodeSearchResult, keyword, secKeyword string) *service.SaveResultStats {
-	searchResults := ConvertToSearchResults(results, keyword, secKeyword)
+func SaveResultWithStats(results []*github.CodeSearchResult, keyword string) *service.SaveResultStats {
+	searchResults := ConvertToSearchResults(results, keyword)
 	return service.SaveSearchResultsWithStats(searchResults)
 }
 
-func ConvertToSearchResults(results []*github.CodeSearchResult, keyword, secKeyword string) []model.SearchResult {
+func ConvertToSearchResults(results []*github.CodeSearchResult, keyword string) []model.SearchResult {
 	searchResults := make([]model.SearchResult, 0)
 	for _, result := range results {
 		codeResults := result.CodeResults
 		for _, codeResult := range codeResults {
 			searchResult := model.SearchResult{
-				RepoUrl:    *codeResult.Repository.HTMLURL,
-				Repo:       *codeResult.Repository.FullName,
-				Keyword:    keyword,
-				SecKeyword: secKeyword,
-				Url:        *codeResult.HTMLURL,
-				Path:       *codeResult.Path,
-				Status:     0,
+				RepoUrl: *codeResult.Repository.HTMLURL,
+				Repo:    *codeResult.Repository.FullName,
+				Keyword: keyword,
+				Url:     *codeResult.HTMLURL,
+				Path:    *codeResult.Path,
+				Status:  0,
 			}
 			if len(codeResult.TextMatches) > 0 {
 				b, err := json.Marshal(codeResult.TextMatches)

--- a/server/service/filter.go
+++ b/server/service/filter.go
@@ -1,12 +1,29 @@
 package service
 
 import (
+	"errors"
+
 	"github.com/madneal/gshark/global"
 	"github.com/madneal/gshark/model"
 	"github.com/madneal/gshark/model/request"
 )
 
+var supportedFilterClasses = map[string]struct{}{
+	"extension": {},
+	"keyword":   {},
+}
+
+func validateFilterClass(class string) error {
+	if _, ok := supportedFilterClasses[class]; !ok {
+		return errors.New("unsupported filter class")
+	}
+	return nil
+}
+
 func CreateFilter(filter model.Filter) (err error) {
+	if err := validateFilterClass(filter.FilterClass); err != nil {
+		return err
+	}
 	return Create(&filter)
 }
 
@@ -19,16 +36,23 @@ func DeleteFilterByIds(ids request.IdsReq) (err error) {
 }
 
 func UpdateFilter(filter model.Filter) (err error) {
+	if err := validateFilterClass(filter.FilterClass); err != nil {
+		return err
+	}
 	return Update(&filter)
 }
 
 func GetFilter(id uint) (err error, filter model.Filter) {
 	filter, err = GetByID[model.Filter](id)
+	if err == nil {
+		err = validateFilterClass(filter.FilterClass)
+	}
 	return
 }
 
 func GetFilterInfoList(info request.FilterSearch) (err error, list interface{}, total int64) {
-	db := global.GVA_DB.Model(&model.Filter{})
+	db := global.GVA_DB.Model(&model.Filter{}).
+		Where("filter_class IN ?", []string{"extension", "keyword"})
 	var filters []model.Filter
 	total, err = Paginate(db, info.Page, info.PageSize, &filters, "")
 	return err, filters, total

--- a/server/service/filter_test.go
+++ b/server/service/filter_test.go
@@ -1,0 +1,17 @@
+package service
+
+import "testing"
+
+func TestValidateFilterClass(t *testing.T) {
+	t.Parallel()
+
+	for _, class := range []string{"extension", "keyword"} {
+		if err := validateFilterClass(class); err != nil {
+			t.Fatalf("expected %q to be supported: %v", class, err)
+		}
+	}
+
+	if err := validateFilterClass("sec_keyword"); err == nil {
+		t.Fatal("expected removed secondary keyword filter class to be rejected")
+	}
+}

--- a/server/service/search_result.go
+++ b/server/service/search_result.go
@@ -12,12 +12,12 @@ import (
 
 // SaveResultStats contains detailed statistics about saved search results
 type SaveResultStats struct {
-	Total      int      // Total results processed
-	Inserted   int      // Successfully inserted
-	Skipped    int      // Skipped (already exists)
-	Failed     int      // Failed to insert
-	Repos      []string // Unique repos affected
-	repoSet    map[string]struct{}
+	Total    int      // Total results processed
+	Inserted int      // Successfully inserted
+	Skipped  int      // Skipped (already exists)
+	Failed   int      // Failed to insert
+	Repos    []string // Unique repos affected
+	repoSet  map[string]struct{}
 }
 
 // NewSaveResultStats creates a new SaveResultStats instance
@@ -78,13 +78,6 @@ func UpdateSearchResultByIds(req request.BatchUpdateReq) (err error) {
 	return err
 }
 
-func IgnoreResultsByRepo(repo string) (err error) {
-	err = global.GVA_DB.Table("search_result").
-		Where("status = ? and repo = ? and (sec_keyword is null or sec_keyword = '')", global.UnhandledStatus, repo).
-		UpdateColumn("status", global.IgnoredStatus).Error
-	return err
-}
-
 func UpdateSearchResult(updateReq request.UpdateReq) (err error) {
 	err = global.GVA_DB.Table("search_result").Where("repo = ?", updateReq.Repo).
 		UpdateColumn("status", updateReq.Status).Error
@@ -115,13 +108,10 @@ func GetSearchResultInfoList(info request.SearchResultSearch) (err error, list i
 			"%"+info.Query+"%", "%"+info.Query+"%")
 	}
 	if info.Keyword != "" {
-		db = db.Where("`keyword` = ? or `sec_keyword` = ?", info.Keyword, info.Keyword)
+		db = db.Where("`keyword` = ?", info.Keyword)
 	}
 	if info.Status >= 0 {
 		db = db.Where("`status` = ?", info.Status)
-	}
-	if info.OnlySecKeyword {
-		db = db.Where("`sec_keyword` != ''")
 	}
 	total, err = Paginate(db, info.Page, info.PageSize, &searchResults, "id desc")
 	return err, searchResults, total
@@ -178,24 +168,4 @@ func SaveSearchResultPointersWithStats(searchResults []*model.SearchResult, keyw
 		results = append(results, *result)
 	}
 	return SaveSearchResultsWithStats(results)
-}
-
-func GetReposByStatus(status int) (error, []string) {
-	var results []model.SearchResult
-	err := global.GVA_DB.Distinct().Select("repo").Where("status = ?",
-		status).Find(&results).Error
-	repos := make([]string, 0)
-	if err != nil {
-		return err, repos
-	}
-	for _, result := range results {
-		repos = append(repos, result.Repo)
-	}
-	return err, repos
-}
-
-func GetKeywordByRepo(repo string) (string, error) {
-	var result model.SearchResult
-	err := global.GVA_DB.Where("repo = ?", repo).First(&result).Error
-	return result.Keyword, err
 }

--- a/server/source/api.go
+++ b/server/source/api.go
@@ -90,8 +90,6 @@ var apis = []model.SysApi{
 	{global.GVA_MODEL{CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/searchResult/getSearchResultList", "获取搜索结果列表", "searchResult", "GET"},
 	{global.GVA_MODEL{CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/searchResult/exportSearchResult", "导出结果列表", "searchResult", "GET"},
 	{global.GVA_MODEL{CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/searchResult/updateSearchResultStatusByIds", "批量更新搜索结果列表", "searchResult", "POST"},
-	{global.GVA_MODEL{CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/searchResult/startSecFilterTask", "开始二次过滤任务", "searchResult", "POST"},
-	{global.GVA_MODEL{CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/searchResult/getTaskStatus", "获取任务状态", "searchResult", "GET"},
 	{global.GVA_MODEL{CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/searchResult/startAITask", "开始 AI 任务", "searchResult", "POST"},
 	{global.GVA_MODEL{CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/subdomain/createSubdomain", "新增子域名", "subdomain", "POST"},
 	{global.GVA_MODEL{CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/subdomain/deleteSubdomain", "删除子域名", "subdomain", "DELETE"},

--- a/server/source/casbin.go
+++ b/server/source/casbin.go
@@ -87,8 +87,6 @@ var carbines = []gormadapter.CasbinRule{
 	{PType: "p", V0: "888", V1: "/searchResult/getSearchResultList", V2: "GET"},
 	{PType: "p", V0: "888", V1: "/searchResult/exportSearchResult", V2: "GET"},
 	{PType: "p", V0: "888", V1: "/searchResult/updateSearchResultStatusByIds", V2: "POST"},
-	{PType: "p", V0: "888", V1: "/searchResult/startSecFilterTask", V2: "POST"},
-	{PType: "p", V0: "888", V1: "/searchResult/getTaskStatus", V2: "GET"},
 	{PType: "p", V0: "888", V1: "/searchResult/startAITask", V2: "POST"},
 	{PType: "p", V0: "888", V1: "/subdomain/createSubdomain", V2: "POST"},
 	{PType: "p", V0: "888", V1: "/subdomain/deleteSubdomain", V2: "DELETE"},

--- a/sql.md
+++ b/sql.md
@@ -1,3 +1,20 @@
+## v2.1.9
+
+Remove the retired secondary keyword filter data after upgrading an existing database:
+
+```sql
+delete from casbin_rule
+where v1 in ('/searchResult/startSecFilterTask', '/searchResult/getTaskStatus');
+
+delete from sys_apis
+where path in ('/searchResult/startSecFilterTask', '/searchResult/getTaskStatus');
+
+delete from filters
+where filter_class = 'sec_keyword';
+
+alter table search_result drop column sec_keyword;
+```
+
 ## v1.4.5
 
 ```
@@ -56,6 +73,7 @@ insert into casbin_rule (p_type, v0, v1, v2) values ('p', 888, '/searchResult/st
 insert into sys_apis (created_at, updated_at, deleted_at, path, description, api_group, method) VALUES
     (current_timestamp, current_timestamp, null, '/searchResult/getTaskStatus', '查询任务状态', 'searchResult', 'GET');
 insert into casbin_rule (p_type, v0, v1, v2) values ('p', 888, '/searchResult/getTaskStatus', 'GET');
+
 ```
 
 ## v1.0.3
@@ -107,9 +125,6 @@ alter table token drop column description;
 insert into sys_apis (created_at, updated_at, deleted_at, path, description, api_group, method) VALUES 
 (current_timestamp, current_timestamp, null, '/email/botTest', '企业微信测试', 'email', 'GET');
 ```
-
-
-
 
 
 

--- a/web/src/api/searchResult.js
+++ b/web/src/api/searchResult.js
@@ -90,20 +90,6 @@ export const exportSearchResult = async (params) => {
      })
  }
 
- export const startFilterTask = () => {
-    return service({
-        url: "/searchResult/startSecFilterTask",
-        method: "post"
-    })
- }
-
- export const getTaskStatus = () => {
-    return service({
-        url: "/searchResult/getTaskStatus",
-        method: "get"
-    })
- }
-
  export const startAITask = () => {
      return service({
          url: "/searchResult/startAITask",

--- a/web/src/view/filter/filter.vue
+++ b/web/src/view/filter/filter.vue
@@ -69,7 +69,6 @@
           <el-radio-group v-model="formData.filter_class">
             <el-radio label="extension">文件后缀</el-radio>
             <el-radio label="keyword">关键词</el-radio>
-            <el-radio label="sec_keyword">二次关键词</el-radio>
           </el-radio-group>
         </el-form-item>
         <el-form-item label="内容：">

--- a/web/src/view/searchResult/searchResult.vue
+++ b/web/src/view/searchResult/searchResult.vue
@@ -33,12 +33,6 @@
             />
           </el-select>
         </el-form-item>
-        <el-form-item label="仅展示二次关键词结果">
-          <el-switch
-            v-model="searchInfo.onlySecKeyword"
-            @change="secKeywordChange"
-          />
-        </el-form-item>
         <el-form-item class="filter-actions">
           <div class="filter-actions__btns">
             <el-button type="primary" @click="onSubmit">查询</el-button>
@@ -63,9 +57,6 @@
           批量忽略
         </el-button>
         <el-button @click="startAITask">启动AI分析</el-button>
-        <el-button :disabled="taskBtnDisable" @click="confirmFilterTask">
-          {{ taskButtonTxt }}
-        </el-button>
       </div>
     </div>
 
@@ -97,7 +88,6 @@
         </template>
       </el-table-column>
       <el-table-column label="关键词" prop="keyword" width="100" show-overflow-tooltip />
-      <el-table-column label="二级关键词" prop="sec_keyword" width="110" show-overflow-tooltip />
       <el-table-column label="日期" width="100">
         <template #default="scope">{{ formatDate(scope.row.CreatedAt) }}</template>
       </el-table-column>
@@ -148,8 +138,6 @@ import {
   getSearchResultList,
   updateSearchResult,
   updateSearchResultStatusByIds,
-  startFilterTask,
-  getTaskStatus,
   exportSearchResult,
   startAITask,
 } from "@/api/searchResult";
@@ -164,8 +152,6 @@ export default {
       listApi: getSearchResultList,
       dialogFormVisible: false,
       type: "",
-      taskButtonTxt: "启动二次过滤",
-      taskBtnDisable: false,
       // null shows placeholder "全部"; normalizeSearchInfo maps it to -1 for the API
       // (backend skips status filter when Status < 0). Do not bind -1 to the select —
       // it is not in statusOptions and would render as the literal "-1".
@@ -272,9 +258,6 @@ export default {
         this.$message({ type: "error", message: "导出失败" });
       }
     },
-    secKeywordChange() {
-      this.getTableData();
-    },
     handleSelectionChange(val) {
       this.multipleSelection = val;
     },
@@ -284,37 +267,6 @@ export default {
         this.$message({ type: "success", message: "已启动 AI 分析任务" });
       } catch (e) {
         this.$message({ type: "error", message: "启动 AI 分析失败" });
-      }
-    },
-    confirmFilterTask() {
-      this.$confirm(
-        "过滤任务将自动忽略未匹配二次过滤关键词的结果，确定启动吗？",
-        "启动二次过滤",
-        {
-          confirmButtonText: "确定",
-          cancelButtonText: "取消",
-          type: "warning",
-        }
-      )
-        .then(() => this.startFilterTask())
-        .catch(() => {});
-    },
-    async startFilterTask() {
-      try {
-        await startFilterTask();
-        const resp = await getTaskStatus();
-        if (resp.msg === "running") {
-          this.taskButtonTxt = "任务运行中";
-          this.taskBtnDisable = true;
-          this.$message({ type: "success", message: "二次过滤任务已启动" });
-        } else {
-          this.$message({
-            type: "warning",
-            message: "二次过滤任务未处于运行状态",
-          });
-        }
-      } catch (e) {
-        this.$message({ type: "error", message: "启动二次过滤失败" });
       }
     },
     confirmBulk(isIgnore) {
@@ -371,14 +323,6 @@ export default {
   },
   async created() {
     await this.getTableData();
-    const resp = await getTaskStatus();
-    if (resp.msg === "running") {
-      this.taskButtonTxt = "任务运行中";
-      this.taskBtnDisable = true;
-    } else {
-      this.taskButtonTxt = "启动二次过滤";
-      this.taskBtnDisable = false;
-    }
   },
 };
 </script>


### PR DESCRIPTION
## Summary

- remove the secondary keyword scan task, status endpoint, API permissions, and result model/query/export fields
- remove the secondary keyword filter option, result-only toggle, result column, and task controls from the web UI
- restrict filter APIs to the supported `extension` and `keyword` classes and hide legacy secondary keyword records
- simplify GitHub result conversion now that results no longer carry a secondary keyword
- update English and Chinese documentation and add upgrade SQL for legacy database metadata/data

Existing databases are not modified automatically. The `v2.1.9` migration in `sql.md` removes the retired API/Casbin entries, filter records, and `search_result.sec_keyword` column. New databases no longer create or seed any secondary keyword behavior.

## Testing

- `GO111MODULE=on GOCACHE=/private/tmp/gshark-go-build-cache go test -run '^$' ./...`
- `GO111MODULE=on GOCACHE=/private/tmp/gshark-go-build-cache go test ./service -run TestValidateFilterClass`
- `GO111MODULE=on GOCACHE=/private/tmp/gshark-go-build-cache go test ./search/githubsearch`
- `npm run build`
- `npx eslint src/api/searchResult.js src/view/filter/filter.vue src/view/searchResult/searchResult.vue`
