### PR TITLE
fix(postman): use official cursor search API

### DIFF
--- a/server/model/search_result.go
+++ b/server/model/search_result.go
@@ -10,7 +10,7 @@ import (
 
 type SearchResult struct {
 	global.GVA_MODEL
-	Repo            string         `json:"repo" form:"repo" gorm:"column:repo;comment:;type:varchar(200);size:200;"`
+	Repo            string         `json:"repo" form:"repo" gorm:"column:repo;comment:;type:varchar(1000);size:1000;"`
 	RepoUrl         string         `gorm:"column:repository;type:varchar(200);"`
 	Matches         string         `json:"matches" form:"matches" gorm:"column:matches;comment:;type:text;"`
 	Keyword         string         `json:"keyword" form:"keyword" gorm:"column:keyword;comment:;type:varchar(100);size:100;"`

--- a/server/search/postman/search.go
+++ b/server/search/postman/search.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	postmanURL             = "https://www.postman.com/_api/ws/proxy"
+	postmanURL             = "https://api.postman.com/search"
 	postmanPageSize        = 25
 	postmanRequestTimeout  = 30 * time.Second
 	maxPostmanResponseSize = 10 << 20
@@ -26,69 +26,45 @@ const (
 
 var postmanHTTPClient = &http.Client{Timeout: postmanRequestTimeout}
 
-type Document struct {
-	Summary            string        `json:"summary"`
-	RequestCount       int           `json:"requestCount"`
-	PublisherType      string        `json:"publisherType"`
-	Imports            int           `json:"imports,omitempty"`
-	WatcherCount       int           `json:"watcherCount"`
-	EntityType         string        `json:"entityType"`
-	ForkCount          int           `json:"forkCount"`
-	Tags               []interface{} `json:"tags"`
-	Quality            int           `json:"quality,omitempty"`
-	PublisherId        string        `json:"publisherId"`
-	ForkLabel          string        `json:"forkLabel"`
-	Apis               []interface{} `json:"apis,omitempty"`
-	PublisherHandle    string        `json:"publisherHandle"`
-	PublisherName      string        `json:"publisherName"`
-	PublisherLogo      string        `json:"publisherLogo"`
-	IsDomainNonTrivial bool          `json:"isDomainNonTrivial"`
-	Name               string        `json:"name"`
-	Method             string        `json:"method"`
-	URL                string        `json:"url"`
-	WorkspaceSlug      string        `json:"workspaceSlug"`
-	IsPublic           bool          `json:"isPublic"`
-	Workspaces         []struct {
-		VisibilityStatus string `json:"visibilityStatus"`
-		Name             string `json:"name"`
-		Id               string `json:"id"`
-		Slug             string `json:"slug"`
-	} `json:"workspaces"`
-	Id           string        `json:"id"`
-	Categories   []interface{} `json:"categories"`
-	Views        int           `json:"views"`
-	DocumentType string        `json:"documentType"`
+type PostmanResourceRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
-type Requests struct {
-	Score    float64 `json:"score"`
-	Document struct {
-		Method string `json:"method"`
-		Name   string `json:"name"`
-		Id     string `json:"id"`
-		Url    string `json:"url"`
-	} `json:"document"`
+type PostmanOrganization struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	IsVerified bool   `json:"isVerified"`
+}
+
+type PostmanLinks struct {
+	Web struct {
+		Href string `json:"href"`
+	} `json:"web"`
+	Self struct {
+		Href string `json:"href"`
+	} `json:"self"`
+}
+
+type PostmanResource struct {
+	ID           string              `json:"id"`
+	Name         string              `json:"name"`
+	Method       string              `json:"method"`
+	Description  string              `json:"description"`
+	URL          string              `json:"url"`
+	Collection   PostmanResourceRef  `json:"collection"`
+	Workspace    PostmanResourceRef  `json:"workspace"`
+	Organization PostmanOrganization `json:"organization"`
+	Team         PostmanResourceRef  `json:"team"`
+	Links        PostmanLinks        `json:"links"`
 }
 
 type PostmanRes struct {
-	Data []struct {
-		Score           float64   `json:"score"`
-		NormalizedScore float64   `json:"normalizedScore"`
-		Document        Document  `json:"document"`
-		Requests        *Requests `json:"requests"`
-	} `json:"data"`
+	Data []PostmanResource `json:"data"`
 	Meta struct {
-		QueryText string `json:"queryText"`
-		Total     struct {
-			Collection int `json:"collection"`
-			Workspace  int `json:"workspace"`
-			Api        int `json:"api"`
-			Team       int `json:"team"`
-			User       int `json:"user"`
-			Request    int `json:"request"`
-		} `json:"total"`
-		State              string `json:"state"`
-		CorrectedQueryText string `json:"correctedQueryText"`
+		QueryText  string `json:"q"`
+		Total      int    `json:"total"`
+		NextCursor string `json:"nextCursor"`
 	} `json:"meta"`
 }
 
@@ -124,30 +100,14 @@ func SearchByType(keyword, searchType string) {
 
 func (res *PostmanRes) ConvertToSearchResult(keyword string) *[]model.SearchResult {
 	results := make([]model.SearchResult, 0)
-	for _, data := range res.Data {
-		document := data.Document
-		name := document.Name
-		method := document.Method
-		requestValue := document.URL
-		requests := data.Requests
-		if requests != nil {
-			if name == "" {
-				name = requests.Document.Name
-			}
-			if method == "" {
-				method = requests.Document.Method
-			}
-			if requestValue == "" {
-				requestValue = requests.Document.Url
-			}
-		}
-		matches := joinNonEmpty(method, name, requestValue, document.Summary)
+	for _, resource := range res.Data {
 		result := model.SearchResult{
-			Path:    document.PublisherName,
-			Url:     buildPostmanURL(document),
-			Matches: matches,
+			Path:    resource.ID,
+			RepoUrl: resource.Links.Web.Href,
+			Url:     resource.Links.Web.Href,
+			Matches: joinNonEmpty(resource.Method, resource.Name, resource.URL, resource.Description),
 			Keyword: keyword,
-			Repo:    document.PublisherName + "/" + name,
+			Repo:    buildPostmanRepo(resource),
 		}
 		results = append(results, result)
 	}
@@ -159,18 +119,22 @@ func SearchAPI(rule, searchType string) (*[]PostmanRes, error) {
 }
 
 type postmanSearchRequest struct {
-	Service string                   `json:"service"`
-	Method  string                   `json:"method"`
-	Path    string                   `json:"path"`
-	Body    postmanSearchRequestBody `json:"body"`
+	ElementType string               `json:"elementType"`
+	QueryText   string               `json:"q"`
+	Ownership   string               `json:"ownership"`
+	Filters     postmanSearchFilters `json:"filters"`
 }
 
-type postmanSearchRequestBody struct {
-	QueryIndices  []string `json:"queryIndices"`
-	QueryText     string   `json:"queryText"`
-	Size          int      `json:"size"`
-	From          int      `json:"from"`
-	MergeEntities bool     `json:"mergeEntities"`
+type postmanSearchFilters struct {
+	And []postmanSearchFilter `json:"$and"`
+}
+
+type postmanSearchFilter struct {
+	Visibility postmanEqualsFilter `json:"visibility"`
+}
+
+type postmanEqualsFilter struct {
+	Equal string `json:"$eq"`
 }
 
 func searchAPI(client *http.Client, endpoint, rule, searchType string) (*[]PostmanRes, error) {
@@ -178,27 +142,32 @@ func searchAPI(client *http.Client, endpoint, rule, searchType string) (*[]Postm
 		return &[]PostmanRes{}, fmt.Errorf("unsupported Postman search type %q", searchType)
 	}
 
+	body, err := json.Marshal(postmanSearchRequest{
+		ElementType: searchType + "s",
+		QueryText:   rule,
+		Ownership:   "all",
+		Filters: postmanSearchFilters{
+			And: []postmanSearchFilter{{
+				Visibility: postmanEqualsFilter{Equal: "public"},
+			}},
+		},
+	})
+	if err != nil {
+		return &[]PostmanRes{}, fmt.Errorf("marshal Postman search request: %w", err)
+	}
+
 	resList := make([]PostmanRes, 0)
-	for page, offset := 0, 0; ; page, offset = page+1, offset+postmanPageSize {
+	seenCursors := make(map[string]struct{})
+	seenResources := make(map[string]struct{})
+	cursor := ""
+	for page := 0; ; page++ {
 		color.Infof("search for the rule %s of page %d\n", rule, page)
-		payload := postmanSearchRequest{
-			Service: "search",
-			Method:  http.MethodPost,
-			Path:    "/search-all",
-			Body: postmanSearchRequestBody{
-				QueryIndices:  []string{"runtime." + searchType},
-				QueryText:     rule,
-				Size:          postmanPageSize,
-				From:          offset,
-				MergeEntities: true,
-			},
-		}
-		body, err := json.Marshal(payload)
+		requestURL, err := buildPostmanSearchURL(endpoint, cursor)
 		if err != nil {
-			return &resList, fmt.Errorf("marshal Postman search page %d: %w", page, err)
+			return &resList, fmt.Errorf("build Postman search page %d URL: %w", page, err)
 		}
 
-		req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+		req, err := http.NewRequest(http.MethodPost, requestURL, bytes.NewReader(body))
 		if err != nil {
 			return &resList, fmt.Errorf("create Postman search request: %w", err)
 		}
@@ -218,15 +187,32 @@ func searchAPI(client *http.Client, endpoint, rule, searchType string) (*[]Postm
 		if err = json.Unmarshal(resBody, &postRes); err != nil {
 			return &resList, fmt.Errorf("decode Postman search page %d: %w", page, err)
 		}
-		resList = append(resList, postRes)
 
-		total := postRes.Meta.Total.Request
-		if searchType == "collection" {
-			total = postRes.Meta.Total.Collection
+		uniqueResources := make([]PostmanResource, 0, len(postRes.Data))
+		for _, resource := range postRes.Data {
+			key := postmanResourceKey(resource)
+			if key != "" {
+				if _, exists := seenResources[key]; exists {
+					continue
+				}
+				seenResources[key] = struct{}{}
+			}
+			uniqueResources = append(uniqueResources, resource)
 		}
-		if len(postRes.Data) == 0 || offset+postmanPageSize >= total {
+		postRes.Data = uniqueResources
+		if len(postRes.Data) > 0 {
+			resList = append(resList, postRes)
+		}
+
+		nextCursor := postRes.Meta.NextCursor
+		if nextCursor == "" {
 			break
 		}
+		if _, exists := seenCursors[nextCursor]; exists {
+			return &resList, fmt.Errorf("Postman search repeated cursor on page %d", page)
+		}
+		seenCursors[nextCursor] = struct{}{}
+		cursor = nextCursor
 	}
 	return &resList, nil
 }
@@ -251,24 +237,36 @@ func readPostmanResponse(res *http.Response) ([]byte, error) {
 	return body, nil
 }
 
-func buildPostmanURL(document Document) string {
-	workspaceSlug := document.WorkspaceSlug
-	if workspaceSlug == "" && len(document.Workspaces) > 0 {
-		workspaceSlug = document.Workspaces[0].Slug
+func buildPostmanSearchURL(endpoint, cursor string) (string, error) {
+	searchURL, err := url.Parse(endpoint)
+	if err != nil {
+		return "", err
 	}
-	if document.PublisherHandle != "" && workspaceSlug != "" && document.Id != "" {
-		return fmt.Sprintf(
-			"https://www.postman.com/%s/workspace/%s/%s/%s",
-			url.PathEscape(document.PublisherHandle),
-			url.PathEscape(workspaceSlug),
-			url.PathEscape(document.DocumentType),
-			url.PathEscape(document.Id),
-		)
+	query := searchURL.Query()
+	query.Set("limit", fmt.Sprintf("%d", postmanPageSize))
+	if cursor != "" {
+		query.Set("cursor", cursor)
 	}
-	if document.DocumentType == "collection" && document.Id != "" {
-		return fmt.Sprintf("https://www.postman.com/workspace/collection/%s", url.PathEscape(document.Id))
+	searchURL.RawQuery = query.Encode()
+	return searchURL.String(), nil
+}
+
+func postmanResourceKey(resource PostmanResource) string {
+	if resource.ID != "" {
+		return resource.ID
+	}
+	if resource.Links.Web.Href != "" {
+		return resource.Links.Web.Href
 	}
 	return ""
+}
+
+func buildPostmanRepo(resource PostmanResource) string {
+	label := joinNonEmpty(resource.Organization.Name, resource.Collection.Name, resource.Name)
+	if resource.ID == "" {
+		return label
+	}
+	return label + " [" + resource.ID + "]"
 }
 
 func joinNonEmpty(values ...string) string {

--- a/server/search/postman/search_test.go
+++ b/server/search/postman/search_test.go
@@ -63,35 +63,44 @@ func TestSearchAPIHandlesTransportError(t *testing.T) {
 }
 
 func TestSearchAPIPaginatesWithOffsetsAndEscapesRule(t *testing.T) {
-	var offsets []int
+	var cursors []string
 	const rule = "key \"quoted\" \\\\ value"
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		var request postmanSearchRequest
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 			return nil, fmt.Errorf("decode request: %w", err)
 		}
-		if request.Body.QueryText != rule {
-			t.Errorf("query text = %q, want %q", request.Body.QueryText, rule)
+		if request.QueryText != rule {
+			t.Errorf("query text = %q, want %q", request.QueryText, rule)
 		}
-		offsets = append(offsets, request.Body.From)
+		if request.ElementType != "requests" {
+			t.Errorf("element type = %q, want requests", request.ElementType)
+		}
+		if r.URL.Query().Get("limit") != "25" {
+			t.Errorf("limit = %q, want 25", r.URL.Query().Get("limit"))
+		}
+		cursors = append(cursors, r.URL.Query().Get("cursor"))
 
 		count := postmanPageSize
-		if request.Body.From == postmanPageSize {
-			count = 5
+		nextCursor := "second-page"
+		start := 0
+		if r.URL.Query().Get("cursor") == "second-page" {
+			count = 2
+			nextCursor = ""
+			start = postmanPageSize - 1
 		}
 		data := make([]map[string]interface{}, count)
 		for i := range data {
 			data[i] = map[string]interface{}{
-				"document": map[string]interface{}{
-					"id":           fmt.Sprintf("request-%d", request.Body.From+i),
-					"documentType": "request",
-				},
+				"id":   fmt.Sprintf("request-%d", start+i),
+				"name": fmt.Sprintf("Request %d", start+i),
 			}
 		}
 		return jsonHTTPResponse(http.StatusOK, map[string]interface{}{
 			"data": data,
 			"meta": map[string]interface{}{
-				"total": map[string]interface{}{"request": 30},
+				"total":      count,
+				"nextCursor": nextCursor,
 			},
 		}), nil
 	})}
@@ -100,10 +109,10 @@ func TestSearchAPIPaginatesWithOffsetsAndEscapesRule(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(offsets, []int{0, 25}) {
-		t.Fatalf("offsets = %v, want [0 25]", offsets)
+	if !reflect.DeepEqual(cursors, []string{"", "second-page"}) {
+		t.Fatalf("cursors = %v, want [\"\" \"second-page\"]", cursors)
 	}
-	if len(*res) != 2 || len((*res)[0].Data)+len((*res)[1].Data) != 30 {
+	if len(*res) != 2 || len((*res)[0].Data)+len((*res)[1].Data) != 26 {
 		t.Fatalf("unexpected response pages: %#v", res)
 	}
 }
@@ -118,13 +127,14 @@ func TestSearchAPIReturnsPartialPagesOnLaterFailure(t *testing.T) {
 		data := make([]map[string]interface{}, postmanPageSize)
 		for i := range data {
 			data[i] = map[string]interface{}{
-				"document": map[string]interface{}{"id": fmt.Sprintf("request-%d", i)},
+				"id": fmt.Sprintf("request-%d", i),
 			}
 		}
 		return jsonHTTPResponse(http.StatusOK, map[string]interface{}{
 			"data": data,
 			"meta": map[string]interface{}{
-				"total": map[string]interface{}{"request": 30},
+				"total":      postmanPageSize,
+				"nextCursor": "second-page",
 			},
 		}), nil
 	})}
@@ -142,15 +152,23 @@ func TestConvertToSearchResultUsesCurrentResponseShape(t *testing.T) {
 	var response PostmanRes
 	err := json.Unmarshal([]byte(`{
 		"data": [{
-			"document": {
-				"id": "request-id",
-				"documentType": "request",
-				"method": "POST",
-				"name": "Chat Completions",
-				"url": "{{baseUrl}}/chat/completions",
-				"publisherName": "Postman DevRel",
-				"publisherHandle": "devrel",
-				"workspaceSlug": "openai"
+			"id": "request-id",
+			"method": "POST",
+			"name": "Chat Completions",
+			"url": "https://api.openai.com/v1/chat/completions",
+			"description": "Create a chat completion",
+			"collection": {
+				"id": "collection-id",
+				"name": "OpenAI API"
+			},
+			"organization": {
+				"id": "organization-id",
+				"name": "Postman DevRel"
+			},
+			"links": {
+				"web": {
+					"href": "https://go.postman.co/request/request-id"
+				}
 			}
 		}]
 	}`), &response)
@@ -163,11 +181,58 @@ func TestConvertToSearchResultUsesCurrentResponseShape(t *testing.T) {
 		t.Fatalf("expected one result, got %d", len(*results))
 	}
 	result := (*results)[0]
-	if result.Url != "https://www.postman.com/devrel/workspace/openai/request/request-id" {
+	if result.Url != "https://go.postman.co/request/request-id" {
 		t.Fatalf("URL = %q", result.Url)
 	}
-	if result.Matches != "POST | Chat Completions | {{baseUrl}}/chat/completions" {
+	if result.RepoUrl != result.Url {
+		t.Fatalf("repository URL = %q, want %q", result.RepoUrl, result.Url)
+	}
+	if result.Path != "request-id" {
+		t.Fatalf("path = %q, want request-id", result.Path)
+	}
+	if result.Matches != "POST | Chat Completions | https://api.openai.com/v1/chat/completions | Create a chat completion" {
 		t.Fatalf("matches = %q", result.Matches)
+	}
+	if result.Repo != "Postman DevRel | OpenAI API | Chat Completions [request-id]" {
+		t.Fatalf("repo = %q", result.Repo)
+	}
+}
+
+func TestBuildPostmanRepoPreservesLongNameAndUniqueIDSuffix(t *testing.T) {
+	resource := PostmanResource{
+		ID:   "request-id",
+		Name: strings.Repeat("长", 250),
+	}
+	resource.Organization.Name = "Postman"
+	resource.Collection.Name = "Collection"
+
+	repo := buildPostmanRepo(resource)
+	want := "Postman | Collection | " + resource.Name + " [request-id]"
+	if repo != want {
+		t.Fatalf("repo = %q, want %q", repo, want)
+	}
+	if len([]rune(repo)) <= 200 {
+		t.Fatalf("test repo length = %d, want more than the old column limit", len([]rune(repo)))
+	}
+	if !strings.HasSuffix(repo, " [request-id]") {
+		t.Fatalf("repo does not preserve ID suffix: %q", repo)
+	}
+}
+
+func TestSearchAPIRejectsRepeatedCursor(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return jsonHTTPResponse(http.StatusOK, map[string]interface{}{
+			"data": []map[string]interface{}{{"id": "request-id"}},
+			"meta": map[string]interface{}{"nextCursor": "same-cursor"},
+		}), nil
+	})}
+
+	res, err := searchAPI(client, "https://postman.test/search", "key", "request")
+	if err == nil || !strings.Contains(err.Error(), "repeated cursor") {
+		t.Fatalf("expected repeated cursor error, got %v", err)
+	}
+	if len(*res) != 1 {
+		t.Fatalf("expected one unique page, got %d", len(*res))
 	}
 }
 

--- a/sql.md
+++ b/sql.md
@@ -1,3 +1,12 @@
+## v2.1.11
+
+Expand the repository field so full Postman request names and identifiers can be stored:
+
+```sql
+alter table search_result
+    modify repo varchar(1000) null;
+```
+
 ## v2.1.9
 
 Remove the retired secondary keyword filter data after upgrading an existing database:
@@ -125,7 +134,6 @@ alter table token drop column description;
 insert into sys_apis (created_at, updated_at, deleted_at, path, description, api_group, method) VALUES 
 (current_timestamp, current_timestamp, null, '/email/botTest', '企业微信测试', 'email', 'GET');
 ```
-
 
 
 


### PR DESCRIPTION
## Summary

- replace the retired internal Postman proxy endpoint with the official public Search API
- follow `meta.nextCursor`, enforce the 25-result page limit, and deduplicate request IDs across pages
- map official response fields to stable result paths, links, matches, and repository labels
- expand `search_result.repo` to `varchar(1000)` and document the v2.1.11 migration so long Postman request names are preserved

## Problem

The previous offset-based endpoint rejects `from` values at or above 200, which stops larger scans with HTTP 400. Its response shape also no longer matches the scanner mapping, and valid Postman repository labels can exceed the existing 200-character database column.

## Validation

- `GOCACHE=/tmp/gshark-go-build GO111MODULE=on go test ./search/postman`
- `GOCACHE=/tmp/gshark-go-build GO111MODULE=on go test -short ./...`
- `GOCACHE=/tmp/gshark-go-build GO111MODULE=on go vet ./search/postman`
- `git diff --check`