### PR TITLE
fix(postman): fall back to workspace name in repo label

### DIFF
--- a/server/search/postman/search.go
+++ b/server/search/postman/search.go
@@ -262,7 +262,11 @@ func postmanResourceKey(resource PostmanResource) string {
 }
 
 func buildPostmanRepo(resource PostmanResource) string {
-	label := joinNonEmpty(resource.Organization.Name, resource.Collection.Name, resource.Name)
+	owner := resource.Organization.Name
+	if owner == "" {
+		owner = resource.Workspace.Name
+	}
+	label := joinNonEmpty(owner, resource.Collection.Name, resource.Name)
 	if resource.ID == "" {
 		return label
 	}

--- a/server/search/postman/search_test.go
+++ b/server/search/postman/search_test.go
@@ -219,6 +219,21 @@ func TestBuildPostmanRepoPreservesLongNameAndUniqueIDSuffix(t *testing.T) {
 	}
 }
 
+func TestBuildPostmanRepoFallsBackToWorkspaceNameWhenOrganizationIsBlank(t *testing.T) {
+	resource := PostmanResource{
+		ID:   "request-id",
+		Name: "Launcher HTML Widget Content",
+	}
+	resource.Collection.Name = "Genshin Launcher"
+	resource.Workspace.Name = "MiHoYo"
+
+	repo := buildPostmanRepo(resource)
+	want := "MiHoYo | Genshin Launcher | Launcher HTML Widget Content [request-id]"
+	if repo != want {
+		t.Fatalf("repo = %q, want %q", repo, want)
+	}
+}
+
 func TestSearchAPIRejectsRepeatedCursor(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return jsonHTTPResponse(http.StatusOK, map[string]interface{}{


### PR DESCRIPTION
## Summary
- Follow-up to #320. `buildPostmanRepo` only used `organization.name` for the owner segment of the repo label, but live Postman search results frequently return an empty `organization` with the owner context only available in `workspace.name` (personal workspaces, team workspaces without a linked org).
- `PostmanResource.Workspace` was already being parsed from the API response but never read anywhere, so this attribution was silently dropped.
- Now falls back to `workspace.name` when `organization.name` is blank.

## Validation
- `GOCACHE=/tmp/gshark-go-build GO111MODULE=on go test ./search/postman/...`
- `GOCACHE=/tmp/gshark-go-build GO111MODULE=on go test -short ./...`
- Ran the gated `RUN_POSTMAN_INTEGRATION=1` test against the live Postman Search API for `mihoyo` before/after: before the fix, results like `Genshin Launcher | Launcher HTML Widget Content [id]` had no owner context; after, they correctly show `MiHoYo | Genshin Launcher | Launcher HTML Widget Content [id]`.