### PR TITLE
fix(github): retry search after rate limit instead of dropping page

### DIFF
--- a/server/search/githubsearch/gitclient.go
+++ b/server/search/githubsearch/gitclient.go
@@ -15,6 +15,10 @@ import (
 type Client struct {
 	Client *github.Client
 	Token  string
+
+	// rotate overrides token rotation in tests; nil means use rotateToken,
+	// which calls NextClient (and therefore hits the database).
+	rotate func() bool
 }
 
 func InitClient(token string) *Client {

--- a/server/search/githubsearch/search.go
+++ b/server/search/githubsearch/search.go
@@ -183,44 +183,102 @@ func BuildQuery(query string) (string, error) {
 	return builtQuery, err
 }
 
+// maxSearchAttempts bounds how many times a single page is retried after
+// hitting a rate limit, so a persistently exhausted token set eventually
+// gives up instead of looping forever.
+const maxSearchAttempts = 3
+
+// sleepFn is overridden in tests so rate-limit backoffs don't actually block.
+var sleepFn = time.Sleep
+
 func (c *Client) searchCodeByOpt(ctx context.Context, query string, opt github.SearchOptions) (*github.CodeSearchResult,
 	int) {
-	result, res, err := c.Client.Search.Code(ctx, query, &opt)
+	for attempt := 1; attempt <= maxSearchAttempts; attempt++ {
+		result, res, err := c.Client.Search.Code(ctx, query, &opt)
+		if err == nil {
+			return c.afterSearchSuccess(query, result, res)
+		}
 
-	// Handle error first
-	if err != nil {
 		var rateLimitError *github.RateLimitError
-		if errors.As(err, &rateLimitError) {
-			global.GVA_LOG.Warn("Trigger the github rate limit")
-			if res != nil {
-				resetTimeStamp := res.Rate.Reset
-				sleepDuration := resetTimeStamp.Sub(time.Now()) + 10*time.Second
-				global.GVA_LOG.Warn(fmt.Sprintf("Ready to sleep for %v", sleepDuration))
-				time.Sleep(sleepDuration)
+		var abuseRateLimitError *github.AbuseRateLimitError
+		switch {
+		case errors.As(err, &rateLimitError):
+			global.GVA_LOG.Warn("Trigger the github rate limit", zap.Int("attempt", attempt))
+			if !c.attemptRotate() {
+				sleepUntil(rateLimitError.Rate.Reset.Time)
 			}
-		} else {
+		case errors.As(err, &abuseRateLimitError):
+			global.GVA_LOG.Warn("Trigger the github secondary rate limit", zap.Int("attempt", attempt))
+			if !c.attemptRotate() {
+				sleepForAbuse(abuseRateLimitError.RetryAfter)
+			}
+		default:
 			global.GVA_LOG.Error("Search error", zap.Any("github search error", err))
-			time.Sleep(30 * time.Second)
+			sleepFn(30 * time.Second)
 			return nil, 0
 		}
 	}
 
-	// Check if response is nil before accessing its fields
+	global.GVA_LOG.Error("exhausted retry attempts for Github search", zap.String("query", query))
+	return nil, 0
+}
+
+func (c *Client) afterSearchSuccess(query string, result *github.CodeSearchResult, res *github.Response) (*github.CodeSearchResult, int) {
 	if res == nil {
 		global.GVA_LOG.Error("Received nil response from GitHub API")
 		return nil, 0
 	}
 
-	// Now safe to access res.Rate
 	if res.Rate.Remaining < 3 {
 		color.Info.Print("the remaining is less than 3, switch to another token\n")
-		newGithubClient, newToken := c.NextClient()
-		c.Client = newGithubClient
-		c.Token = newToken
+		c.attemptRotate()
 	}
 
 	global.GVA_LOG.Info("Search for "+query, zap.Any("remaining", res.Rate.Remaining), zap.Any("nextPage",
 		res.NextPage), zap.Any("lastPage", res.LastPage))
 
 	return result, res.NextPage
+}
+
+// attemptRotate switches to the next configured github token and reports
+// whether it actually changed to a different token. Tests inject c.rotate
+// to avoid hitting the database; production code falls back to rotateToken.
+func (c *Client) attemptRotate() bool {
+	if c.rotate != nil {
+		return c.rotate()
+	}
+	return c.rotateToken()
+}
+
+// rotateToken switches to the next configured github token and reports
+// whether it actually changed to a different token. When only one token is
+// configured, NextClient returns the same token, so callers know to fall
+// back to sleeping instead of busy-retrying with the same exhausted token.
+func (c *Client) rotateToken() bool {
+	previousToken := c.Token
+	newGithubClient, newToken := c.NextClient()
+	if newGithubClient == nil || newToken == "" || newToken == previousToken {
+		return false
+	}
+	c.Client = newGithubClient
+	c.Token = newToken
+	return true
+}
+
+func sleepUntil(reset time.Time) {
+	sleepDuration := time.Until(reset) + 10*time.Second
+	if sleepDuration < 0 {
+		sleepDuration = 10 * time.Second
+	}
+	global.GVA_LOG.Warn(fmt.Sprintf("Ready to sleep for %v", sleepDuration))
+	sleepFn(sleepDuration)
+}
+
+func sleepForAbuse(retryAfter *time.Duration) {
+	sleepDuration := 60 * time.Second
+	if retryAfter != nil {
+		sleepDuration = *retryAfter + 5*time.Second
+	}
+	global.GVA_LOG.Warn(fmt.Sprintf("Ready to sleep for %v due to secondary rate limit", sleepDuration))
+	sleepFn(sleepDuration)
 }

--- a/server/search/githubsearch/search_test.go
+++ b/server/search/githubsearch/search_test.go
@@ -1,11 +1,27 @@
 package githubsearch
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v57/github"
 	"github.com/madneal/gshark/global"
 	"github.com/madneal/gshark/initialize"
 	"github.com/madneal/gshark/model"
-	"testing"
+	"go.uber.org/zap"
 )
+
+func TestMain(m *testing.M) {
+	global.GVA_LOG = zap.NewNop()
+	os.Exit(m.Run())
+}
 
 func TestSearch(t *testing.T) {
 	global.GVA_VP = initialize.Viper("../../config.yaml") // 初始化Viper
@@ -23,4 +39,175 @@ func TestSearch(t *testing.T) {
 
 func TestSearchWithNoRules(t *testing.T) {
 	Search(nil)
+}
+
+func newTestClient(t *testing.T, handler http.HandlerFunc) (*Client, func() *github.Client) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newGithubClient := func() *github.Client {
+		ghClient := github.NewClient(server.Client())
+		ghClient.BaseURL = baseURL
+		return ghClient
+	}
+
+	return &Client{Client: newGithubClient(), Token: "test-token"}, newGithubClient
+}
+
+func stubSleep(t *testing.T) *[]time.Duration {
+	t.Helper()
+	var slept []time.Duration
+	original := sleepFn
+	sleepFn = func(d time.Duration) { slept = append(slept, d) }
+	t.Cleanup(func() { sleepFn = original })
+	return &slept
+}
+
+func writeRateLimitResponse(w http.ResponseWriter, resetAt time.Time) {
+	w.Header().Set("X-RateLimit-Remaining", "0")
+	w.Header().Set("X-RateLimit-Reset", fmt.Sprintf("%d", resetAt.Unix()))
+	w.WriteHeader(http.StatusForbidden)
+	_ = json.NewEncoder(w).Encode(map[string]string{"message": "API rate limit exceeded"})
+}
+
+func writeAbuseRateLimitResponse(w http.ResponseWriter, retryAfterSeconds int) {
+	w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfterSeconds))
+	w.WriteHeader(http.StatusForbidden)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"message":           "You have exceeded a secondary rate limit",
+		"documentation_url": "https://docs.github.com/rest/overview/rate-limits-for-the-rest-api#secondary-rate-limits",
+	})
+}
+
+func writeSearchSuccess(w http.ResponseWriter, result github.CodeSearchResult) {
+	w.Header().Set("X-RateLimit-Remaining", "100")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+func TestSearchCodeByOptRetriesAfterRotatingOnPrimaryRateLimit(t *testing.T) {
+	stubSleep(t)
+	requestCount := 0
+	client, newGithubClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			writeRateLimitResponse(w, time.Now().Add(time.Hour))
+			return
+		}
+		writeSearchSuccess(w, github.CodeSearchResult{
+			Total:       github.Int(1),
+			CodeResults: []*github.CodeResult{{Path: github.String("main.go")}},
+		})
+	})
+
+	rotated := false
+	client.rotate = func() bool {
+		rotated = true
+		// A real token rotation builds a brand-new *github.Client (see
+		// InitGithubClient), which also resets go-github's internal
+		// per-category rate-limit cache. Mirror that here so the retried
+		// request isn't short-circuited by the cached 403 from attempt 1.
+		client.Client = newGithubClient()
+		return true
+	}
+
+	result, nextPage := client.searchCodeByOpt(context.Background(), "test query", github.SearchOptions{})
+	if !rotated {
+		t.Fatal("expected rotate to be invoked after hitting the primary rate limit")
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected the search request to be retried once, got %d attempts", requestCount)
+	}
+	if result == nil || len(result.CodeResults) != 1 {
+		t.Fatalf("expected the retried request's result to be returned, got %#v", result)
+	}
+	if nextPage != 0 {
+		t.Fatalf("nextPage = %d, want 0", nextPage)
+	}
+}
+
+func TestSearchCodeByOptSleepsAndRetriesWhenRotationUnavailable(t *testing.T) {
+	slept := stubSleep(t)
+	requestCount := 0
+	// resetAt is already in the past: sleepFn is stubbed out (no real wait),
+	// so the reset time must have already elapsed or go-github's own
+	// client-side rate-limit cache would short-circuit the retry itself.
+	resetAt := time.Now().Add(-time.Second)
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			writeRateLimitResponse(w, resetAt)
+			return
+		}
+		writeSearchSuccess(w, github.CodeSearchResult{Total: github.Int(0)})
+	})
+	client.rotate = func() bool { return false }
+
+	result, _ := client.searchCodeByOpt(context.Background(), "test query", github.SearchOptions{})
+	if len(*slept) != 1 {
+		t.Fatalf("expected exactly one sleep call, got %d", len(*slept))
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected the search request to be retried once, got %d attempts", requestCount)
+	}
+	if result == nil {
+		t.Fatal("expected a result after the retried request succeeded")
+	}
+}
+
+func TestSearchCodeByOptRetriesAfterRotatingOnSecondaryRateLimit(t *testing.T) {
+	stubSleep(t)
+	requestCount := 0
+	client, newGithubClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			writeAbuseRateLimitResponse(w, 1)
+			return
+		}
+		writeSearchSuccess(w, github.CodeSearchResult{Total: github.Int(0)})
+	})
+
+	rotated := false
+	client.rotate = func() bool {
+		rotated = true
+		client.Client = newGithubClient()
+		return true
+	}
+
+	_, _ = client.searchCodeByOpt(context.Background(), "test query", github.SearchOptions{})
+	if !rotated {
+		t.Fatal("expected rotate to be invoked after hitting the secondary rate limit")
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected the search request to be retried once, got %d attempts", requestCount)
+	}
+}
+
+func TestSearchCodeByOptGivesUpAfterMaxAttempts(t *testing.T) {
+	stubSleep(t)
+	requestCount := 0
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		writeRateLimitResponse(w, time.Now().Add(time.Hour))
+	})
+	client.rotate = func() bool { return false }
+
+	result, nextPage := client.searchCodeByOpt(context.Background(), "test query", github.SearchOptions{})
+	if result != nil || nextPage != 0 {
+		t.Fatalf("expected no result after exhausting retries, got (%#v, %d)", result, nextPage)
+	}
+	// Without rotation or an elapsed reset, go-github's own client-side rate
+	// cache short-circuits attempts 2+ locally, so only the first attempt
+	// reaches the server; the important assertion is that the retry loop
+	// still terminates (bounded by maxSearchAttempts) instead of looping
+	// forever or hammering the server on every attempt.
+	if requestCount < 1 || requestCount > maxSearchAttempts {
+		t.Fatalf("expected between 1 and %d attempts to reach the server, got %d", maxSearchAttempts, requestCount)
+	}
 }


### PR DESCRIPTION
## Summary
- `searchCodeByOpt` previously slept out the GitHub rate-limit window but never retried the request, so pages hit during a rate limit were silently dropped from search results.
- The secondary/abuse rate limit (`*github.AbuseRateLimitError`) wasn't handled at all — it fell through to the generic error branch, sleeping 30s and dropping the page.
- Now on either error type, the client first tries `NextClient()` token rotation and retries immediately; only falls back to sleeping until `Rate.Reset`/`RetryAfter` when rotation isn't available (e.g. only one token configured). Bounded to `maxSearchAttempts` (3) so an exhausted token set still terminates instead of looping forever.

## Test plan
- [x] `go build ./...` from `server/`
- [x] `go test ./search/githubsearch/... -short` — new unit tests cover: retry-after-rotation on primary limit, sleep-and-retry fallback when rotation is unavailable, retry-after-rotation on secondary/abuse limit, and bounded termination when retries are exhausted
- [x] The existing live-DB integration test (`TestSearch`) exercised the new code path against real GitHub rate limiting during local testing — it hit a real rate limit, rotated tokens, and retried successfully instead of dropping the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)