### PR TITLE
ci: publish release images to Docker Hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,10 @@ name: Release
 
 on:
   release:
-    types: [prereleased, edited, published]
+    types: [prereleased, published]
 
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -105,7 +107,58 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.event.release.tag_name }} ./release/*
-        
-    
-    
-        
+
+  container-images:
+    name: Docker ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: gshark
+            context: ./server
+            dockerfile: ./server/deploy/serve/Dockerfile
+          - image: gshark-web
+            context: ./web
+            dockerfile: ./web/Dockerfile
+
+    steps:
+      - name: Fetch Sources
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}
+          tags: |
+            type=raw,value=${{ github.event.release.tag_name }}
+            type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          provenance: mode=max
+          sbom: true

--- a/README.md
+++ b/README.md
@@ -66,7 +66,24 @@ Use one of the two quick deployment entries:
 
 ## Docker Deployment
 
+Use the published images from Docker Hub:
+
+```bash
+export GSHARK_VERSION=v2.1.11
+docker compose pull server web
+docker compose up -d mysql server web
+
+# Optional: start the scanner after database initialization
+docker compose up -d scan
 ```
+
+`server` and `scan` share the `dongne/gshark` image, while the frontend uses
+`dongne/gshark-web`. Pin `GSHARK_VERSION` to a release tag for reproducible
+deployments.
+
+Build from source:
+
+```bash
 # Clone the repository
 git clone https://github.com/madneal/gshark
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -66,7 +66,23 @@ gshark / gshark
 
 ## Docker 部署
 
+使用 Docker Hub 上的正式发布镜像：
+
+```bash
+export GSHARK_VERSION=v2.1.11
+docker compose pull server web
+docker compose up -d mysql server web
+
+# 可选：数据库初始化完成后启动扫描器
+docker compose up -d scan
 ```
+
+`server` 和 `scan` 共用 `dongne/gshark` 镜像，前端使用
+`dongne/gshark-web`。将 `GSHARK_VERSION` 固定为 release tag 可以确保部署版本可复现。
+
+从源码构建：
+
+```bash
 # 克隆仓库
 git clone https://github.com/madneal/gshark
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,6 +31,7 @@ services:
         ipv4_address: 177.7.0.13
 
   web:
+    image: ${GSHARK_WEB_IMAGE:-dongne/gshark-web}:${GSHARK_VERSION:-latest}
     build:
       context: ./web
       dockerfile: ./Dockerfile
@@ -46,6 +47,7 @@ services:
         ipv4_address: 177.7.0.11
 
   server:
+    image: ${GSHARK_IMAGE:-dongne/gshark}:${GSHARK_VERSION:-latest}
     build:
       context: ./server
       dockerfile: deploy/serve/Dockerfile
@@ -67,9 +69,11 @@ services:
         ipv4_address: 177.7.0.12
 
   scan:
+    image: ${GSHARK_IMAGE:-dongne/gshark}:${GSHARK_VERSION:-latest}
     build:
       context: ./server
-      dockerfile: deploy/scan/Dockerfile
+      dockerfile: deploy/serve/Dockerfile
+    command: [ "scan" ]
     environment:
       - GSHARK_CONFIG=config.docker.yaml
     container_name: gshark-scanner

--- a/server/deploy/scan/Dockerfile
+++ b/server/deploy/scan/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 as builder
+FROM golang:1.25 AS builder
 
 ENV GSHARK_CONFIG=config.docker.yaml
 WORKDIR /go/src/github.com/madneal/gshark/server
@@ -15,10 +15,12 @@ FROM alpine:latest
 
 LABEL MAINTAINER="root@madneal.com"
 
+ENV GSHARK_CONFIG=config.docker.yaml
 WORKDIR /go/src/github.com/madneal/gshark/server
 
 COPY --from=0 /go/src/github.com/madneal/gshark/server/gshark ./
 COPY --from=0 /go/src/github.com/madneal/gshark/server/resource ./resource/
 COPY --from=0 /go/src/github.com/madneal/gshark/server/config.docker.yaml ./
 
-ENTRYPOINT ./gshark scan
+ENTRYPOINT ["./gshark"]
+CMD ["scan"]

--- a/server/deploy/serve/Dockerfile
+++ b/server/deploy/serve/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 as builder
+FROM golang:1.25 AS builder
 
 ENV GSHARK_CONFIG=config.docker.yaml
 WORKDIR /go/src/github.com/madneal/gshark/server
@@ -15,6 +15,7 @@ FROM alpine:latest
 
 LABEL MAINTAINER="root@madneal.com"
 
+ENV GSHARK_CONFIG=config.docker.yaml
 WORKDIR /go/src/github.com/madneal/gshark/server
 
 COPY --from=0 /go/src/github.com/madneal/gshark/server/gshark ./
@@ -22,4 +23,5 @@ COPY --from=0 /go/src/github.com/madneal/gshark/server/resource ./resource/
 COPY --from=0 /go/src/github.com/madneal/gshark/server/config.docker.yaml ./
 
 EXPOSE 8888
-ENTRYPOINT ./gshark serve
+ENTRYPOINT ["./gshark"]
+CMD ["serve"]


### PR DESCRIPTION
## Summary

- publish `dongne/gshark` and `dongne/gshark-web` from GitHub Releases
- build multi-platform `linux/amd64` and `linux/arm64` images with SBOM and provenance
- tag every image with the release tag and update `latest` only for stable releases
- reuse the backend image for both `serve` and `scan` commands
- let Compose pull a pinned `GSHARK_VERSION` while retaining local build support
- document Docker Hub deployment in English and Chinese

## Docker Hub

The public repositories are ready:

- https://hub.docker.com/r/dongne/gshark
- https://hub.docker.com/r/dongne/gshark-web

The repository Actions secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are configured. Images will first be pushed when a release containing this workflow is published.

## Validation

- built the backend image locally
- built the web image locally
- verified backend `ENTRYPOINT=["./gshark"]`, default `CMD=["serve"]`, and `scan` command override
- verified `docker compose config` with `GSHARK_VERSION=v2.1.11`
- parsed `.github/workflows/release.yml` as YAML
- checked Markdown fence balance and `git diff --check`