### PR TITLE
docs: add pull-only release compose

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Fetch Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -43,7 +43,9 @@ jobs:
       - name: Move config
         run: |
           cp ./server/config-temp.yaml ./release/gshark_darwin_amd64/ && cp ./server/config-temp.yaml ./release/gshark_windows_amd64/ &&
-          cp ./server/config-temp.yaml ./release/gshark_linux_amd64/ && cp ./server/config-temp.yaml ./release/gshark_darwin_arm64/ 
+          cp ./server/config-temp.yaml ./release/gshark_linux_amd64/ && cp ./server/config-temp.yaml ./release/gshark_darwin_arm64/ &&
+          cp ./server/config.docker.yaml ./release/config.docker.yaml &&
+          cp ./docker-compose.release.yaml ./release/docker-compose.release.yaml
 
       - name: Move resource
         run: |
@@ -56,9 +58,10 @@ jobs:
           cp -rf ./web/dist ./release/gshark_linux_amd64/ && cp -rf ./web/dist ./release/gshark_darwin_arm64/
 
       - name: Go Setup
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
 
       - name: Go Mod Tidy
         working-directory: ./server
@@ -124,25 +127,25 @@ jobs:
 
     steps:
       - name: Fetch Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Generate image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}
           tags: |

--- a/README.md
+++ b/README.md
@@ -69,17 +69,24 @@ Use one of the two quick deployment entries:
 Use the published images from Docker Hub:
 
 ```bash
-export GSHARK_VERSION=v2.1.11
-docker compose pull server web
-docker compose up -d mysql server web
+mkdir gshark && cd gshark
+export GSHARK_VERSION=v2.1.12
+
+curl -fLO "https://github.com/madneal/gshark/releases/download/${GSHARK_VERSION}/docker-compose.release.yaml"
+curl -fLO "https://github.com/madneal/gshark/releases/download/${GSHARK_VERSION}/config.docker.yaml"
+
+docker compose -f docker-compose.release.yaml pull
+docker compose -f docker-compose.release.yaml up -d mysql server web
 
 # Optional: start the scanner after database initialization
-docker compose up -d scan
+docker compose -f docker-compose.release.yaml up -d scan
 ```
 
 `server` and `scan` share the `dongne/gshark` image, while the frontend uses
-`dongne/gshark-web`. Pin `GSHARK_VERSION` to a release tag for reproducible
-deployments.
+`dongne/gshark-web`. The release Compose file contains no source builds and
+requires `GSHARK_VERSION` to be an explicit release tag. MySQL data is stored in
+the `mysql-data` named volume and is preserved when application containers are
+replaced.
 
 Build from source:
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -69,16 +69,23 @@ gshark / gshark
 使用 Docker Hub 上的正式发布镜像：
 
 ```bash
-export GSHARK_VERSION=v2.1.11
-docker compose pull server web
-docker compose up -d mysql server web
+mkdir gshark && cd gshark
+export GSHARK_VERSION=v2.1.12
+
+curl -fLO "https://github.com/madneal/gshark/releases/download/${GSHARK_VERSION}/docker-compose.release.yaml"
+curl -fLO "https://github.com/madneal/gshark/releases/download/${GSHARK_VERSION}/config.docker.yaml"
+
+docker compose -f docker-compose.release.yaml pull
+docker compose -f docker-compose.release.yaml up -d mysql server web
 
 # 可选：数据库初始化完成后启动扫描器
-docker compose up -d scan
+docker compose -f docker-compose.release.yaml up -d scan
 ```
 
 `server` 和 `scan` 共用 `dongne/gshark` 镜像，前端使用
-`dongne/gshark-web`。将 `GSHARK_VERSION` 固定为 release tag 可以确保部署版本可复现。
+`dongne/gshark-web`。发布版 Compose 不包含源码构建，并要求
+`GSHARK_VERSION` 明确指定 release tag。MySQL 数据保存在 `mysql-data`
+named volume 中，替换应用容器不会删除数据库数据。
 
 从源码构建：
 

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -1,0 +1,80 @@
+name: gshark
+
+networks:
+  network:
+    ipam:
+      driver: default
+      config:
+        - subnet: "177.7.0.0/16"
+
+volumes:
+  mysql-data:
+
+services:
+  mysql:
+    image: mysql/mysql-server:8.0.21
+    container_name: gshark-mysql
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    restart: always
+    ports:
+      - "13306:3306"
+    environment:
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_DATABASE: gshark
+      MYSQL_ROOT_PASSWORD: madneal
+      MYSQL_USER: gshark
+      MYSQL_PASSWORD: gshark
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 2s
+      retries: 10
+    networks:
+      network:
+        ipv4_address: 177.7.0.13
+
+  web:
+    image: dongne/gshark-web:${GSHARK_VERSION:?Set GSHARK_VERSION to a release tag}
+    container_name: gshark-web
+    restart: always
+    ports:
+      - "8080:8080"
+    depends_on:
+      - server
+    networks:
+      network:
+        ipv4_address: 177.7.0.11
+
+  server:
+    image: dongne/gshark:${GSHARK_VERSION:?Set GSHARK_VERSION to a release tag}
+    container_name: gshark-server
+    environment:
+      GSHARK_CONFIG: config.docker.yaml
+    volumes:
+      - ./config.docker.yaml:/go/src/github.com/madneal/gshark/server/config.docker.yaml:ro
+    restart: always
+    ports:
+      - "8888:8888"
+    depends_on:
+      mysql:
+        condition: service_healthy
+    networks:
+      network:
+        ipv4_address: 177.7.0.12
+
+  scan:
+    image: dongne/gshark:${GSHARK_VERSION:?Set GSHARK_VERSION to a release tag}
+    container_name: gshark-scanner
+    command: ["scan"]
+    environment:
+      GSHARK_CONFIG: config.docker.yaml
+    volumes:
+      - ./config.docker.yaml:/go/src/github.com/madneal/gshark/server/config.docker.yaml:ro
+    restart: "no"
+    depends_on:
+      mysql:
+        condition: service_healthy
+    networks:
+      network:
+        ipv4_address: 177.7.0.14

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,6 @@ services:
         ipv4_address: 177.7.0.13
 
   web:
-    image: ${GSHARK_WEB_IMAGE:-dongne/gshark-web}:${GSHARK_VERSION:-latest}
     build:
       context: ./web
       dockerfile: ./Dockerfile
@@ -47,7 +46,6 @@ services:
         ipv4_address: 177.7.0.11
 
   server:
-    image: ${GSHARK_IMAGE:-dongne/gshark}:${GSHARK_VERSION:-latest}
     build:
       context: ./server
       dockerfile: deploy/serve/Dockerfile
@@ -69,7 +67,6 @@ services:
         ipv4_address: 177.7.0.12
 
   scan:
-    image: ${GSHARK_IMAGE:-dongne/gshark}:${GSHARK_VERSION:-latest}
     build:
       context: ./server
       dockerfile: deploy/serve/Dockerfile


### PR DESCRIPTION
## Summary

- add a pull-only `docker-compose.release.yaml` with hardcoded Docker Hub repositories and no source build configuration
- require an explicit `GSHARK_VERSION` release tag instead of silently using `latest`
- persist MySQL in a named volume and mount only the downloaded Docker config
- upload the release Compose and `config.docker.yaml` as GitHub Release assets
- keep the existing `docker-compose.yaml` dedicated to source builds
- update English and Chinese deployment instructions so users download two small release files instead of cloning source
- upgrade release actions to Node 24 based major versions and fix the Go cache dependency path

## Deployment flow

```bash
mkdir gshark && cd gshark
export GSHARK_VERSION=v2.1.12
curl -fLO "https://github.com/madneal/gshark/releases/download/${GSHARK_VERSION}/docker-compose.release.yaml"
curl -fLO "https://github.com/madneal/gshark/releases/download/${GSHARK_VERSION}/config.docker.yaml"
docker compose -f docker-compose.release.yaml pull
docker compose -f docker-compose.release.yaml up -d mysql server web
```

## Validation

- verified release Compose contains no `build` services
- verified exact `dongne/gshark` and `dongne/gshark-web` versioned images
- verified a missing `GSHARK_VERSION` is rejected
- verified MySQL uses the `mysql-data` named volume
- parsed the release workflow YAML
- validated both Compose files and Markdown fences
- `git diff --check`