### PR TITLE
fix(gitlab): fall back to per-project crawl when global search unsupported

### DIFF
--- a/server/config-temp.yaml
+++ b/server/config-temp.yaml
@@ -35,6 +35,8 @@ search:
   gobuster-filepath:
   subdomain-wordlist:
   searchnum: 10
+  gitlab-discover-pages: 5
+  gitlab-batch-size: 50
 system:
   env: public
   addr: 8888

--- a/server/config.docker.yaml
+++ b/server/config.docker.yaml
@@ -35,6 +35,8 @@ search:
   gobuster-filepath: ""
   subdomain-wordlist: ""
   searchnum: 10
+  gitlab-discover-pages: 5
+  gitlab-batch-size: 50
 system:
   env: public
   addr: 8888

--- a/server/config/search.go
+++ b/server/config/search.go
@@ -1,7 +1,9 @@
 package config
 
 type Search struct {
-	GobusterFilePath  string `mapstructure:"gobuster-filepath" json:"gobuster-filepath" yaml:"gobuster-filepath"`
-	SubdomainWordList string `mapstructure:"subdomain-wordlist" json:"subdomain-wordlist" yaml:"subdomain-wordlist"`
-	SearchNum         int    `mapstructure:"searchnum" json:"searchnum" yaml:"searchnum"`
+	GobusterFilePath    string `mapstructure:"gobuster-filepath" json:"gobuster-filepath" yaml:"gobuster-filepath"`
+	SubdomainWordList   string `mapstructure:"subdomain-wordlist" json:"subdomain-wordlist" yaml:"subdomain-wordlist"`
+	SearchNum           int    `mapstructure:"searchnum" json:"searchnum" yaml:"searchnum"`
+	GitlabDiscoverPages int    `mapstructure:"gitlab-discover-pages" json:"gitlab-discover-pages" yaml:"gitlab-discover-pages"`
+	GitlabBatchSize     int    `mapstructure:"gitlab-batch-size" json:"gitlab-batch-size" yaml:"gitlab-batch-size"`
 }

--- a/server/search/gitlabsearch/search.go
+++ b/server/search/gitlabsearch/search.go
@@ -4,6 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/gookit/color"
 	"github.com/madneal/gshark/global"
 	"github.com/madneal/gshark/model"
@@ -11,92 +16,136 @@ import (
 	"github.com/xanzy/go-gitlab"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"strings"
-	"sync"
-	"time"
+)
+
+// defaultGitlabDiscoverPages/defaultGitlabBatchSize bound the per-cycle crawl
+// fallback when global search is unavailable (see RunGlobalSearchTask). They
+// are used whenever the matching config value is unset (<= 0).
+const (
+	defaultGitlabDiscoverPages   = 5
+	defaultGitlabBatchSize       = 50
+	maxConcurrentProjectSearches = 5
 )
 
 func RunTask(duration time.Duration) {
-	//RunSearchTask(GenerateSearchCodeTask())
+	client := GetClient()
+	if client == nil {
+		color.Warnln("There is no client for Gitlab, please check if you specify Gitlab token")
+		time.Sleep(duration * time.Second)
+		return
+	}
+
 	err, rules := service.GetValidRulesByType("gitlab")
 	if err != nil {
 		global.GVA_LOG.Error("GetValidRulesByType gitlab err", zap.Error(err))
 		return
 	}
-	RunSearchTask(&rules, duration)
-	global.GVA_LOG.Info(fmt.Sprintf("Complete the scan of GitLab, start to sleep %d seconds", duration))
-}
-
-func GenerateSearchCodeTask() (map[int][]model.Rule, error) {
-	result := make(map[int][]model.Rule)
-	err, rules := service.GetValidRulesByType("gitlab")
-	ruleNum := len(rules)
-	batch := ruleNum / global.GVA_CONFIG.Search.SearchNum
-
-	for i := 0; i < batch; i++ {
-		result[i] = rules[global.GVA_CONFIG.Search.SearchNum*i : global.GVA_CONFIG.Search.SearchNum*(i+1)]
-	}
-
-	if ruleNum%global.GVA_CONFIG.Search.SearchNum != 0 {
-		result[batch] = rules[global.GVA_CONFIG.Search.SearchNum*batch : ruleNum]
-	}
-	return result, err
-}
-
-func RunSearchTask(rules *[]model.Rule, duration time.Duration) {
-	client := GetClient()
-	if client == nil {
-		color.Warnln("There is no client for Gitlab, please check if you specify Gitlab token")
+	if len(rules) == 0 {
+		time.Sleep(duration * time.Second)
 		return
 	}
-	for _, rule := range *rules {
-		blobs := SearchBlobs(client, rule.Content)
-		results := ConvertBlobsToResults(client, blobs, rule.Content)
-		SaveResult(results, &rule.Content)
+
+	if !RunGlobalSearchTask(client, rules) {
+		global.GVA_LOG.Info("GitLab global blob search unavailable (no Advanced Search), falling back to per-project crawl")
+		GetProjects(client, discoverPages())
+		RunSearchTaskByProject(NextProjectBatch(batchSize()), rules, client)
 	}
+	global.GVA_LOG.Info(fmt.Sprintf("Complete the scan of GitLab, start to sleep %d seconds", duration))
 	time.Sleep(duration * time.Second)
 }
 
-func RunSearchTaskByProject(mapRules map[int][]model.Rule, err error) {
-	client := GetClient()
-	if client == nil {
-		return
+func discoverPages() int {
+	if global.GVA_CONFIG.Search.GitlabDiscoverPages > 0 {
+		return global.GVA_CONFIG.Search.GitlabDiscoverPages
 	}
-	// get all public projects
-	GetProjects(client)
-	if err == nil {
-		for _, rules := range mapRules {
-			startTime := time.Now()
-			Search(rules, client)
-			usedTime := time.Since(startTime).Seconds()
-			if usedTime < 60 {
-				time.Sleep(time.Duration(60 - usedTime))
-			}
-		}
-	}
+	return defaultGitlabDiscoverPages
 }
 
-func Search(rules []model.Rule, client *gitlab.Client) {
-	var wg sync.WaitGroup
-	wg.Add(len(rules))
+func batchSize() int {
+	if global.GVA_CONFIG.Search.GitlabBatchSize > 0 {
+		return global.GVA_CONFIG.Search.GitlabBatchSize
+	}
+	return defaultGitlabBatchSize
+}
 
-	for _, rule := range rules {
-		go func(rule model.Rule) {
+// isGlobalSearchUnsupported reports whether resp is GitLab's specific response
+// for scope=blobs search without Advanced Search/Elasticsearch enabled (HTTP
+// 400 "Scope not supported without Elasticsearch!"). GitLab.com disables this
+// by default even on paid tiers; self-hosted instances may not have it
+// configured either.
+func isGlobalSearchUnsupported(resp *gitlab.Response) bool {
+	return resp != nil && resp.StatusCode == http.StatusBadRequest
+}
+
+// RunGlobalSearchTask attempts GitLab's global blobs search for every rule.
+// It returns false as soon as the first rule reports the instance doesn't
+// support it, so RunTask can fall back to the per-project crawl for the whole
+// cycle instead of eating one guaranteed-failing request per rule. Instances
+// with Advanced Search enabled (self-hosted with Elasticsearch, or GitLab.com
+// Ultimate with it turned on) get full global coverage here.
+func RunGlobalSearchTask(client *gitlab.Client, rules []model.Rule) bool {
+	for i, rule := range rules {
+		blobs, resp, ok := SearchBlobs(client, rule.Content)
+		if !ok {
+			if i == 0 && isGlobalSearchUnsupported(resp) {
+				return false
+			}
+			continue
+		}
+		results := ConvertBlobsToResults(client, blobs, rule.Content)
+		SaveResult(results, &rule.Content)
+	}
+	return true
+}
+
+// NextProjectBatch returns up to batchSize not-yet-searched gitlab repos. If
+// every known repo has already been searched, it recycles the whole pool
+// (resets status back to unsearched) so the crawl never permanently stalls.
+func NextProjectBatch(batchSize int) []model.Repo {
+	valid := ListValidProjects()
+	if len(*valid) == 0 {
+		if err := service.ResetRepoStatusByType("gitlab"); err != nil {
+			global.GVA_LOG.Error("reset gitlab repo status error", zap.Error(err))
+			return nil
+		}
+		valid = ListValidProjects()
+	}
+	if len(*valid) > batchSize {
+		return (*valid)[:batchSize]
+	}
+	return *valid
+}
+
+// RunSearchTaskByProject runs every rule against every project in a bounded
+// worker pool, then marks each project searched so subsequent cycles pick up
+// where this one left off.
+func RunSearchTaskByProject(projects []model.Repo, rules []model.Rule, client *gitlab.Client) {
+	if len(projects) == 0 || len(rules) == 0 {
+		return
+	}
+
+	sem := make(chan struct{}, maxConcurrentProjectSearches)
+	var wg sync.WaitGroup
+	for _, project := range projects {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(project model.Repo) {
 			defer wg.Done()
-			SearchInsideProjects(rule.Content, client)
-		}(rule)
+			defer func() { <-sem }()
+			searchProjectForRules(project, rules, client)
+		}(project)
 	}
 	wg.Wait()
 }
 
-func SearchInsideProjects(keyword string, client *gitlab.Client) {
-	err, projects := service.GetRepoByType("gitlab")
-	if err != nil {
-		global.GVA_LOG.Error("list projects error", zap.Any("err", err))
+func searchProjectForRules(project model.Repo, rules []model.Rule, client *gitlab.Client) {
+	for _, rule := range rules {
+		results := SearchCode(rule.Content, project, client)
+		SaveResult(results, &rule.Content)
 	}
-	for _, project := range projects {
-		results := SearchCode(keyword, project, client)
-		SaveResult(results, &keyword)
+	project.Status = 1
+	if err := service.UpdateRepo(project); err != nil {
+		global.GVA_LOG.Error("mark gitlab project searched error", zap.Error(err))
 	}
 }
 
@@ -108,64 +157,58 @@ func SaveResult(results []*model.SearchResult, keyword *string) {
 	global.GVA_LOG.Info(stats.Summary(*keyword, "GitLab"))
 }
 
+// SearchCode searches for keyword inside a single project, paginating through
+// every page of results.
 func SearchCode(keyword string, project model.Repo, client *gitlab.Client) []*model.SearchResult {
 	codeResults := make([]*model.SearchResult, 0)
-	//queryString := BuildQueryString(keyword, "ext")
 	global.GVA_LOG.Info(fmt.Sprintf("Search inside project %s", project.Path))
-	results, resp, err := client.Search.BlobsByProject(project.ProjectId, keyword, &gitlab.SearchOptions{})
-	if err != nil {
-		global.GVA_LOG.Error("search inside project error", zap.Error(err))
-	}
-	if resp != nil && resp.StatusCode != 200 {
-		global.GVA_LOG.Info(fmt.Sprintf("Request error for project statuscode %d", resp.StatusCode))
-		return codeResults
-	}
-	for _, result := range results {
-		url := project.Url + "/blob/master/" + result.Filename
-		textMatches := make([]model.TextMatch, 0)
-		textMatch := model.TextMatch{
-			Fragment: &result.Data,
-		}
-		textMatches = append(textMatches, textMatch)
-		b, err := json.Marshal(textMatches)
+	opt := &gitlab.SearchOptions{Page: 1, PerPage: 100}
+	for {
+		results, resp, err := client.Search.BlobsByProject(project.ProjectId, keyword, opt)
 		if err != nil {
-			global.GVA_LOG.Error("json marshal error", zap.Error(err))
+			global.GVA_LOG.Error("search inside project error", zap.Error(err))
+			break
 		}
-		codeResult := model.SearchResult{
-			Path:            result.Filename,
-			Repo:            result.Basename,
-			Url:             url,
-			TextMatchesJson: b,
-			Status:          0,
-			Keyword:         keyword,
+		if resp != nil && resp.StatusCode != http.StatusOK {
+			global.GVA_LOG.Info(fmt.Sprintf("Request error for project statuscode %d", resp.StatusCode))
+			break
 		}
-		//if !mergeTextMatches(codeResults, result.Filename, textMatch) {
-		codeResults = append(codeResults, &codeResult)
-		//}
-
+		for _, result := range results {
+			url := project.Url + "/blob/master/" + result.Filename
+			textMatches := make([]model.TextMatch, 0)
+			textMatch := model.TextMatch{
+				Fragment: &result.Data,
+			}
+			textMatches = append(textMatches, textMatch)
+			b, err := json.Marshal(textMatches)
+			if err != nil {
+				global.GVA_LOG.Error("json marshal error", zap.Error(err))
+			}
+			codeResult := model.SearchResult{
+				Path:            result.Filename,
+				Repo:            result.Basename,
+				Url:             url,
+				TextMatchesJson: b,
+				Status:          0,
+				Keyword:         keyword,
+			}
+			codeResults = append(codeResults, &codeResult)
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
 	}
 	return codeResults
 }
 
-// mergeTextMatches is utilized to merge multi textMatches in the same file
-// return: if has merged
-//func mergeTextMatches(codeResults []*model.SearchResult, filename string, textMatch models.TextMatch) bool {
-//	flag := false
-//	for index, result := range codeResults {
-//		if *result.Name == filename {
-//			flag = true
-//			codeResults[index].TextMatches = append(codeResults[index].TextMatches, textMatch)
-//			return flag
-//		}
-//	}
-//	return flag
-//}
-
+// ListValidProjects returns every known gitlab repo that hasn't been searched
+// yet (Status != 1).
 func ListValidProjects() *[]model.Repo {
 	validProjects := make([]model.Repo, 0)
 	err, projects := service.GetRepoByType("gitlab")
 	if err != nil {
-		global.GVA_LOG.Error("list projects error", zap.Error(err))
+		global.GVA_LOG.Error("list projects error", zap.Any("err", err))
 	}
 	for _, p := range projects {
 		// if the project has been searched
@@ -196,29 +239,32 @@ func GetClient() *gitlab.Client {
 }
 
 // SearchBlobBySearchOptions is utilized to search inside blob by keyword
-func SearchBlobBySearchOptions(client *gitlab.Client, keyword string, searchOptions *gitlab.SearchOptions) ([]*gitlab.Blob, int) {
-	blobs, res, err := client.Search.Blobs(keyword, searchOptions)
-	if err != nil {
-		global.GVA_LOG.Error("SearchBlob error", zap.Error(err))
-	}
-	return blobs, res.NextPage
+func SearchBlobBySearchOptions(client *gitlab.Client, keyword string, searchOptions *gitlab.SearchOptions) ([]*gitlab.Blob, *gitlab.Response, error) {
+	blobs, resp, err := client.Search.Blobs(keyword, searchOptions)
+	return blobs, resp, err
 }
 
-// SearchBlobs is utilized to search all the results by keyword
-func SearchBlobs(client *gitlab.Client, keyword string) []*gitlab.Blob {
+// SearchBlobs is utilized to search all the results by keyword via GitLab's
+// global scope=blobs search. This only succeeds when the instance has
+// Advanced Search/Elasticsearch enabled; the returned bool is false otherwise
+// (or on any other request failure), with resp carrying the failing response
+// so callers can tell "unsupported" apart from a transient error.
+func SearchBlobs(client *gitlab.Client, keyword string) ([]*gitlab.Blob, *gitlab.Response, bool) {
 	blobs := make([]*gitlab.Blob, 0)
-	searchOptions := &gitlab.SearchOptions{
-		Page:    1,
-		PerPage: 100,
+	opt := &gitlab.SearchOptions{Page: 1, PerPage: 100}
+	for {
+		page, resp, err := SearchBlobBySearchOptions(client, keyword, opt)
+		if err != nil {
+			global.GVA_LOG.Error("SearchBlobs error", zap.Error(err))
+			return blobs, resp, false
+		}
+		blobs = append(blobs, page...)
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
 	}
-	currentPage := 1
-	for currentPage > 0 {
-		blobResults, nextPage := SearchBlobBySearchOptions(client, keyword, searchOptions)
-		searchOptions.Page = nextPage
-		currentPage = nextPage
-		blobs = append(blobs, blobResults...)
-	}
-	return blobs
+	return blobs, nil, true
 }
 
 // GetProjectById is utilized to get the project by id
@@ -257,8 +303,10 @@ func ConvertBlobsToResults(client *gitlab.Client, blobs []*gitlab.Blob, keyword 
 	return results
 }
 
-// GetProjects is utilized to obtain public projects from gitlab
-func GetProjects(client *gitlab.Client) {
+// GetProjects discovers recently-active public projects from gitlab, upserting
+// them into the repo table for the crawl fallback. maxPages bounds how many
+// pages are fetched in a single call (<= 0 means unbounded).
+func GetProjects(client *gitlab.Client, maxPages int) {
 	isSimple := true
 	date := time.Now().AddDate(0, -1, 0)
 	opt := &gitlab.ListProjectsOptions{
@@ -270,6 +318,7 @@ func GetProjects(client *gitlab.Client) {
 		LastActivityAfter: &date,
 	}
 	projectNum := 0
+	pagesFetched := 0
 	for {
 		// Get the first page with projects.
 		ps, resp, err := client.Projects.ListProjects(opt)
@@ -305,12 +354,17 @@ func GetProjects(client *gitlab.Client) {
 			}
 		}
 
+		pagesFetched++
+		if maxPages > 0 && pagesFetched >= maxPages {
+			break
+		}
+
 		if resp.NextPage == 0 {
 			fmt.Println("next page is 0")
 			break
 		}
 
-		if resp.StatusCode != 200 {
+		if resp.StatusCode != http.StatusOK {
 			fmt.Printf("request error: %d", resp.StatusCode)
 			break
 		}

--- a/server/search/gitlabsearch/search_test.go
+++ b/server/search/gitlabsearch/search_test.go
@@ -1,13 +1,25 @@
 package gitlabsearch
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
 	"github.com/madneal/gshark/global"
 	"github.com/madneal/gshark/initialize"
 	"github.com/madneal/gshark/model"
 	"github.com/stretchr/testify/assert"
-	"testing"
+	"github.com/xanzy/go-gitlab"
+	"go.uber.org/zap"
 )
+
+func TestMain(m *testing.M) {
+	global.GVA_LOG = zap.NewNop()
+	os.Exit(m.Run())
+}
 
 func TestGetClient(t *testing.T) {
 	InitialDataBase()
@@ -36,7 +48,7 @@ func TestGetProjects(t *testing.T) {
 	if client == nil {
 		t.Skip("gitlab client not available (no token)")
 	}
-	GetProjects(client)
+	GetProjects(client, 1)
 }
 
 func TestListValidProjects(t *testing.T) {
@@ -50,27 +62,6 @@ func TestListValidProjects(t *testing.T) {
 	}
 	projects := ListValidProjects()
 	assert.Equal(t, true, len(*projects) > 0, "there is should one more project")
-}
-
-func TestSearchInsideProjects(t *testing.T) {
-	InitialDataBase()
-	if global.GVA_DB == nil {
-		t.Skip("database not available")
-	}
-	client := GetClient()
-	if client == nil {
-		t.Skip("gitlab client not available (no token)")
-	}
-	SearchInsideProjects("spdb", client)
-}
-
-func TestSearchBlog(t *testing.T) {
-	InitialDataBase()
-	if global.GVA_DB == nil {
-		t.Skip("database not available")
-	}
-	//client := GetClient()
-	//SearchBlob(client, "mihoyo")
 }
 
 func TestGetProjectById(t *testing.T) {
@@ -94,21 +85,133 @@ func TestSearchBlobs(t *testing.T) {
 	if client == nil {
 		t.Skip("gitlab client not available (no token)")
 	}
-	blobs := SearchBlobs(client, "mihoyo")
+	blobs, _, _ := SearchBlobs(client, "mihoyo")
 	fmt.Println(blobs)
 }
 
-func TestRunSearchTask(t *testing.T) {
+func TestNextProjectBatch(t *testing.T) {
 	InitialDataBase()
 	if global.GVA_DB == nil {
 		t.Skip("database not available")
 	}
-	client := GetClient()
-	if client == nil {
-		t.Skip("gitlab client not available (no token)")
+	batch := NextProjectBatch(1)
+	assert.Equal(t, true, len(batch) <= 1, "batch should be truncated to the requested size")
+}
+
+func newTestGitlabClient(t *testing.T, handler http.HandlerFunc) *gitlab.Client {
+	t.Helper()
+	// gitlab.Client makes one throwaway GET to the bare base URL the first
+	// time it's used, to read rate-limit headers and configure its limiter
+	// (see (*gitlab.Client).configureLimiter). Absorb that here so callers'
+	// handlers only see the API calls they actually care about.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v4/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		handler(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := gitlab.NewClient("test-token", gitlab.WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatal(err)
 	}
-	rules := []model.Rule{model.Rule{
-		Content: "mihoyo",
-	}}
-	RunSearchTask(&rules, 0)
+	return client
+}
+
+func writeGitlabJSON(w http.ResponseWriter, status int, value interface{}) {
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func TestIsGlobalSearchUnsupported(t *testing.T) {
+	if !isGlobalSearchUnsupported(&gitlab.Response{Response: &http.Response{StatusCode: http.StatusBadRequest}}) {
+		t.Fatal("expected 400 response to be reported as unsupported")
+	}
+	if isGlobalSearchUnsupported(&gitlab.Response{Response: &http.Response{StatusCode: http.StatusInternalServerError}}) {
+		t.Fatal("expected 500 response to not be reported as unsupported")
+	}
+	if isGlobalSearchUnsupported(nil) {
+		t.Fatal("expected a nil response to not be reported as unsupported")
+	}
+}
+
+func TestSearchBlobsReturnsNotOkOnBadRequest(t *testing.T) {
+	client := newTestGitlabClient(t, func(w http.ResponseWriter, r *http.Request) {
+		writeGitlabJSON(w, http.StatusBadRequest, map[string]string{"message": "Scope not supported without Elasticsearch!"})
+	})
+
+	blobs, resp, ok := SearchBlobs(client, "test-query")
+	if ok {
+		t.Fatal("expected ok to be false on a 400 response")
+	}
+	if len(blobs) != 0 {
+		t.Fatalf("expected no blobs, got %d", len(blobs))
+	}
+	if resp == nil || resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected the 400 response to be returned, got %#v", resp)
+	}
+}
+
+func TestSearchBlobsPaginatesUntilNextPageIsZero(t *testing.T) {
+	requestCount := 0
+	client := newTestGitlabClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("X-Next-Page", "2")
+			writeGitlabJSON(w, http.StatusOK, []gitlab.Blob{{Basename: "first"}})
+			return
+		}
+		writeGitlabJSON(w, http.StatusOK, []gitlab.Blob{{Basename: "second"}})
+	})
+
+	blobs, resp, ok := SearchBlobs(client, "test-query")
+	if !ok {
+		t.Fatal("expected ok to be true")
+	}
+	if resp != nil {
+		t.Fatalf("expected a nil response after a fully successful paginated search, got %#v", resp)
+	}
+	if len(blobs) != 2 {
+		t.Fatalf("expected blobs from both pages, got %d", len(blobs))
+	}
+}
+
+func TestRunGlobalSearchTaskFallsBackWhenUnsupported(t *testing.T) {
+	requestCount := 0
+	client := newTestGitlabClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		writeGitlabJSON(w, http.StatusBadRequest, map[string]string{"message": "Scope not supported without Elasticsearch!"})
+	})
+
+	rules := []model.Rule{{Content: "first"}, {Content: "second"}}
+	if RunGlobalSearchTask(client, rules) {
+		t.Fatal("expected RunGlobalSearchTask to report unavailable global search")
+	}
+	if requestCount != 1 {
+		t.Fatalf("expected to stop after the first rule's 400 response, got %d requests", requestCount)
+	}
+}
+
+func TestSearchCodePaginatesAcrossPages(t *testing.T) {
+	requestCount := 0
+	client := newTestGitlabClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("X-Next-Page", "2")
+			writeGitlabJSON(w, http.StatusOK, []gitlab.Blob{{Filename: "a.go", Basename: "a.go"}})
+			return
+		}
+		writeGitlabJSON(w, http.StatusOK, []gitlab.Blob{{Filename: "b.go", Basename: "b.go"}})
+	})
+
+	project := model.Repo{ProjectId: 1, Url: "https://gitlab.test/group/project"}
+	results := SearchCode("test-query", project, client)
+	if requestCount != 2 {
+		t.Fatalf("expected two paginated requests, got %d", requestCount)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected results from both pages, got %d", len(results))
+	}
 }

--- a/server/service/repo.go
+++ b/server/service/repo.go
@@ -43,6 +43,13 @@ func GetRepoByType(typeStr string) (err error, repos []model.Repo) {
 	return err, repos
 }
 
+// ResetRepoStatusByType marks every repo of the given type as unsearched again,
+// so a bounded per-cycle crawl (e.g. gitlabsearch's project crawl) can recycle
+// its pool once every known repo has been searched.
+func ResetRepoStatusByType(typeStr string) (err error) {
+	return global.GVA_DB.Model(&model.Repo{}).Where("type = ?", typeStr).Update("status", 0).Error
+}
+
 func CheckRepoExist(repo *model.Repo) (err error, result bool) {
 	r := global.GVA_DB.Where("project_id = ?", repo.ProjectId).First(repo)
 	err = r.Error


### PR DESCRIPTION
## Summary
- GitLab.com disables Advanced Search (Elasticsearch) by default even on paid tiers, so the global `scope=blobs` search silently returns nothing for most accounts — GitLab responds with HTTP 400 `"Scope not supported without Elasticsearch!"`.
- `RunTask` now tries the global search first (so instances with Advanced Search enabled, self-hosted or GitLab.com Ultimate, still get full coverage), and only falls back to a bounded per-project crawl once it detects that specific unsupported signal on the first rule of a cycle.
- The crawl fallback (previously dead code) is fixed and made production-ready: `SearchCode` now paginates across all result pages (it only fetched page 1 before), `GetProjects` discovery is bounded per cycle via new `gitlab-discover-pages`/`gitlab-batch-size` config knobs (falling back to sane defaults when unset), the old unbounded-goroutine-per-rule loop is replaced with a bounded worker pool over projects, and searched projects are marked so the pool recycles once fully exhausted.
- The existing `searchcode` rule type (querying searchcode.com) remains the supplemental third-party index for GitLab-hosted code — unchanged.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./search/gitlabsearch/... ./service/...`
- [x] `go test ./search/gitlabsearch/... -v` — new unit tests cover the 400-detection fallback logic, blob-search pagination, and per-project search pagination via `httptest`; DB/token-gated tests skip locally as before
- [x] `go test ./service/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)