### PR TITLE
revert: stop publishing Docker Hub images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,8 @@ name: Release
 
 on:
   release:
-    types: [prereleased, published]
+    types: [prereleased, edited, published]
 
-permissions:
-  contents: write
 
 jobs:
   build:
@@ -107,58 +105,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.event.release.tag_name }} ./release/*
-
-  container-images:
-    name: Docker ${{ matrix.image }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - image: gshark
-            context: ./server
-            dockerfile: ./server/deploy/serve/Dockerfile
-          - image: gshark-web
-            context: ./web
-            dockerfile: ./web/Dockerfile
-
-    steps:
-      - name: Fetch Sources
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.release.tag_name }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Generate image metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}
-          tags: |
-            type=raw,value=${{ github.event.release.tag_name }}
-            type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
-
-      - name: Build and push image
-        uses: docker/build-push-action@v7
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
-          provenance: mode=max
-          sbom: true

--- a/README.md
+++ b/README.md
@@ -66,24 +66,7 @@ Use one of the two quick deployment entries:
 
 ## Docker Deployment
 
-Use the published images from Docker Hub:
-
-```bash
-export GSHARK_VERSION=v2.1.11
-docker compose pull server web
-docker compose up -d mysql server web
-
-# Optional: start the scanner after database initialization
-docker compose up -d scan
 ```
-
-`server` and `scan` share the `dongne/gshark` image, while the frontend uses
-`dongne/gshark-web`. Pin `GSHARK_VERSION` to a release tag for reproducible
-deployments.
-
-Build from source:
-
-```bash
 # Clone the repository
 git clone https://github.com/madneal/gshark
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -66,23 +66,7 @@ gshark / gshark
 
 ## Docker 部署
 
-使用 Docker Hub 上的正式发布镜像：
-
-```bash
-export GSHARK_VERSION=v2.1.11
-docker compose pull server web
-docker compose up -d mysql server web
-
-# 可选：数据库初始化完成后启动扫描器
-docker compose up -d scan
 ```
-
-`server` 和 `scan` 共用 `dongne/gshark` 镜像，前端使用
-`dongne/gshark-web`。将 `GSHARK_VERSION` 固定为 release tag 可以确保部署版本可复现。
-
-从源码构建：
-
-```bash
 # 克隆仓库
 git clone https://github.com/madneal/gshark
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,6 @@ services:
         ipv4_address: 177.7.0.13
 
   web:
-    image: ${GSHARK_WEB_IMAGE:-dongne/gshark-web}:${GSHARK_VERSION:-latest}
     build:
       context: ./web
       dockerfile: ./Dockerfile
@@ -47,7 +46,6 @@ services:
         ipv4_address: 177.7.0.11
 
   server:
-    image: ${GSHARK_IMAGE:-dongne/gshark}:${GSHARK_VERSION:-latest}
     build:
       context: ./server
       dockerfile: deploy/serve/Dockerfile
@@ -69,11 +67,9 @@ services:
         ipv4_address: 177.7.0.12
 
   scan:
-    image: ${GSHARK_IMAGE:-dongne/gshark}:${GSHARK_VERSION:-latest}
     build:
       context: ./server
-      dockerfile: deploy/serve/Dockerfile
-    command: [ "scan" ]
+      dockerfile: deploy/scan/Dockerfile
     environment:
       - GSHARK_CONFIG=config.docker.yaml
     container_name: gshark-scanner

--- a/server/deploy/scan/Dockerfile
+++ b/server/deploy/scan/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.25 as builder
 
 ENV GSHARK_CONFIG=config.docker.yaml
 WORKDIR /go/src/github.com/madneal/gshark/server
@@ -15,12 +15,10 @@ FROM alpine:latest
 
 LABEL MAINTAINER="root@madneal.com"
 
-ENV GSHARK_CONFIG=config.docker.yaml
 WORKDIR /go/src/github.com/madneal/gshark/server
 
 COPY --from=0 /go/src/github.com/madneal/gshark/server/gshark ./
 COPY --from=0 /go/src/github.com/madneal/gshark/server/resource ./resource/
 COPY --from=0 /go/src/github.com/madneal/gshark/server/config.docker.yaml ./
 
-ENTRYPOINT ["./gshark"]
-CMD ["scan"]
+ENTRYPOINT ./gshark scan

--- a/server/deploy/serve/Dockerfile
+++ b/server/deploy/serve/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.25 as builder
 
 ENV GSHARK_CONFIG=config.docker.yaml
 WORKDIR /go/src/github.com/madneal/gshark/server
@@ -15,7 +15,6 @@ FROM alpine:latest
 
 LABEL MAINTAINER="root@madneal.com"
 
-ENV GSHARK_CONFIG=config.docker.yaml
 WORKDIR /go/src/github.com/madneal/gshark/server
 
 COPY --from=0 /go/src/github.com/madneal/gshark/server/gshark ./
@@ -23,5 +22,4 @@ COPY --from=0 /go/src/github.com/madneal/gshark/server/resource ./resource/
 COPY --from=0 /go/src/github.com/madneal/gshark/server/config.docker.yaml ./
 
 EXPOSE 8888
-ENTRYPOINT ["./gshark"]
-CMD ["serve"]
+ENTRYPOINT ./gshark serve


### PR DESCRIPTION
## Summary
- remove Docker Hub image builds from the release workflow
- restore the source-build Docker Compose deployment
- remove published-image instructions from the READMEs
- restore the dedicated scanner Dockerfile behavior

This reverts PR #323. PR #324 has also been closed, so deployment remains repository-based: clone the repository and run Docker Compose locally.

## Validation
- `docker compose -f docker-compose.yaml config --quiet`
- parsed `.github/workflows/release.yml` as YAML
- `git diff --check`
- confirmed no Docker Hub publishing references remain
