### PR TITLE
fix(scanner): bound Searchcode requests and isolate provider failures

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/gookit/color v1.3.1
 	github.com/lestrrat-go/file-rotatelogs v2.3.0+incompatible
 	github.com/mojocn/base64Captcha v1.3.6
-	github.com/parnurzeal/gorequest v0.2.16
 	github.com/satori/go.uuid v1.2.0
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/spf13/cobra v1.8.1
@@ -37,7 +36,6 @@ require (
 	github.com/bytedance/sonic v1.9.1 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/elazarl/goproxy v0.0.0-20210110162100-a92cc753f88e // indirect
 	github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
@@ -115,5 +113,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/postgres v1.6.0 // indirect
 	gorm.io/driver/sqlserver v1.6.3 // indirect
-	moul.io/http2curl v1.0.0 // indirect
 )

--- a/server/go.sum
+++ b/server/go.sum
@@ -90,9 +90,6 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
-github.com/elazarl/goproxy v0.0.0-20210110162100-a92cc753f88e h1:/cwV7t2xezilMljIftb7WlFtzGANRCnoOhPjtl2ifcs=
-github.com/elazarl/goproxy v0.0.0-20210110162100-a92cc753f88e/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
-github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 h1:Ghm4eQYC0nEPnSJdVkTrXpu9KtoVCSo1hg7mtI7G9KU=
 github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239/go.mod h1:Gdwt2ce0yfBxPvZrHkprdPPTTS3N5rwmLE8T22KBXlw=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -407,8 +404,6 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
-github.com/parnurzeal/gorequest v0.2.16 h1:T/5x+/4BT+nj+3eSknXmCTnEVGSzFzPGdpqmUVVZXHQ=
-github.com/parnurzeal/gorequest v0.2.16/go.mod h1:3Kh2QUMJoqw3icWAecsyzkpY7UzRfDhbRdTjtNwNiUE=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
@@ -438,7 +433,6 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
-github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
@@ -870,7 +864,5 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
-moul.io/http2curl v1.0.0 h1:6XwpyZOYsgZJrU8exnG87ncVkU1FVCcTRpwzOkTDUi8=
-moul.io/http2curl v1.0.0/go.mod h1:f6cULg+e4Md/oW1cYmwW4IWQOVl2lGbmCNGOHvzX2kE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/server/search/codesearch/search.go
+++ b/server/search/codesearch/search.go
@@ -3,14 +3,26 @@ package codesearch
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/madneal/gshark/global"
-	"github.com/madneal/gshark/model"
-	"github.com/madneal/gshark/service"
-	"github.com/parnurzeal/gorequest"
-	"go.uber.org/zap"
+	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/madneal/gshark/global"
+	"github.com/madneal/gshark/model"
+	"github.com/madneal/gshark/service"
+	"go.uber.org/zap"
+)
+
+const (
+	searchcodeRequestTimeout = 30 * time.Second
+	maxSearchcodePages       = 50 // defensive cap; normal results end via hasResult=false
+)
+
+var (
+	searchcodeHTTPClient = &http.Client{Timeout: searchcodeRequestTimeout}
+	searchcodeBaseURL    = "https://searchcode.com/api/codesearch_I/"
 )
 
 func RunTask(duration time.Duration) {
@@ -23,13 +35,12 @@ func RunTask(duration time.Duration) {
 		global.GVA_LOG.Info("Rules of search code is empty")
 		return
 	}
-	request := gorequest.New()
 	for _, rule := range rules {
 		global.GVA_LOG.Info(fmt.Sprintf("Search for %s in searchcode", rule.Content))
-		codeResults := SearchForSearchCode(rule, request)
+		codeResults := SearchForSearchCode(rule, searchcodeHTTPClient)
 		SaveResults(codeResults, &rule.Content)
 	}
-	global.GVA_LOG.Info(fmt.Sprintf("Compelete the scan of searchcode"))
+	global.GVA_LOG.Info("Complete the scan of searchcode")
 	time.Sleep(duration * time.Second)
 }
 
@@ -41,16 +52,14 @@ func SaveResults(results []*model.SearchResult, keyword *string) {
 	global.GVA_LOG.Info(stats.Summary(*keyword, "SearchCode"))
 }
 
-func SearchForSearchCode(rule model.Rule, request *gorequest.SuperAgent) []*model.SearchResult {
+func SearchForSearchCode(rule model.Rule, client *http.Client) []*model.SearchResult {
 	keyword := rule.Content
 	totalCodeResults := make([]*model.SearchResult, 0)
-	page := 0
-	for {
-		url := "https://searchcode.com/api/codesearch_I/?q=" + keyword + "&p=" + strconv.Itoa(page)
+	for page := 0; page < maxSearchcodePages; page++ {
+		url := searchcodeBaseURL + "?q=" + keyword + "&p=" + strconv.Itoa(page)
 		global.GVA_LOG.Info("search searchcode result for page " + strconv.Itoa(page))
-		codeResults, hasResult := GetResult(request, url)
+		codeResults, hasResult := GetResult(client, url)
 		totalCodeResults = append(totalCodeResults, codeResults...)
-		page++
 		if !hasResult {
 			break
 		}
@@ -58,24 +67,36 @@ func SearchForSearchCode(rule model.Rule, request *gorequest.SuperAgent) []*mode
 	return totalCodeResults
 }
 
-func GetResult(request *gorequest.SuperAgent, url string) ([]*model.SearchResult, bool) {
-	hasResult := true
+func GetResult(client *http.Client, url string) ([]*model.SearchResult, bool) {
 	codeResults := make([]*model.SearchResult, 0)
-	resp, body, err := request.Get(url).End()
-	if err != nil {
+
+	resp, err := client.Get(url)
+	if err != nil || resp == nil {
 		global.GVA_LOG.Error("search result of search code error", zap.Any("err", err))
+		return codeResults, false
 	}
-	if resp.StatusCode != 200 {
-		fmt.Printf("Request to %s error, status code: %d", url, resp.StatusCode)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		global.GVA_LOG.Error(fmt.Sprintf("Request to %s error, status code: %d", url, resp.StatusCode))
+		return codeResults, false
 	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		global.GVA_LOG.Error("read searchcode response body err", zap.Error(err))
+		return codeResults, false
+	}
+
 	var result model.SearchCodeRes
-	jErr := json.Unmarshal([]byte(body), &result)
-	if jErr != nil {
+	if jErr := json.Unmarshal(body, &result); jErr != nil {
 		global.GVA_LOG.Error("json unmarshal searchCodeRes err", zap.Error(jErr))
+		return codeResults, false
 	}
+
 	results := result.Results
 	if len(results) == 0 {
-		hasResult = false
+		return codeResults, false
 	}
 	for _, val := range results {
 		if strings.Contains(val.Repo, "github") {
@@ -101,5 +122,5 @@ func GetResult(request *gorequest.SuperAgent, url string) ([]*model.SearchResult
 		}
 		codeResults = append(codeResults, &codeResult)
 	}
-	return codeResults, hasResult
+	return codeResults, true
 }

--- a/server/search/codesearch/search_test.go
+++ b/server/search/codesearch/search_test.go
@@ -1,0 +1,135 @@
+package codesearch
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/madneal/gshark/global"
+	"github.com/madneal/gshark/model"
+	"go.uber.org/zap"
+)
+
+func TestMain(m *testing.M) {
+	global.GVA_LOG = zap.NewNop()
+	os.Exit(m.Run())
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func jsonHTTPResponse(status int, value interface{}) *http.Response {
+	var body bytes.Buffer
+	_ = json.NewEncoder(&body).Encode(value)
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(&body),
+		Header:     make(http.Header),
+	}
+}
+
+func TestGetResultHandlesTransportError(t *testing.T) {
+	client := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("network unavailable")
+		}),
+	}
+
+	results, hasResult := GetResult(client, "https://searchcode.test/api/codesearch_I/?q=key&p=0")
+	if hasResult {
+		t.Fatalf("expected hasResult=false on transport error")
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected no results, got %d", len(results))
+	}
+}
+
+func TestGetResultReturnsNoResultsOnNon2xx(t *testing.T) {
+	client := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return jsonHTTPResponse(http.StatusNotFound, map[string]string{"error": "not found"}), nil
+		}),
+	}
+
+	results, hasResult := GetResult(client, "https://searchcode.test/api/codesearch_I/?q=key&p=0")
+	if hasResult {
+		t.Fatalf("expected hasResult=false on non-2xx response")
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected no results, got %d", len(results))
+	}
+}
+
+func TestGetResultStopsOnInvalidJSON(t *testing.T) {
+	client := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString("not json")),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	results, hasResult := GetResult(client, "https://searchcode.test/api/codesearch_I/?q=key&p=0")
+	if hasResult {
+		t.Fatalf("expected hasResult=false on invalid JSON")
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected no results, got %d", len(results))
+	}
+}
+
+func TestGetResultRespectsTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := &http.Client{Timeout: 20 * time.Millisecond}
+
+	done := make(chan struct{})
+	var hasResult bool
+	go func() {
+		_, hasResult = GetResult(client, server.URL)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if hasResult {
+			t.Fatalf("expected hasResult=false when the client times out")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetResult did not return within the expected bound after client timeout")
+	}
+}
+
+func TestSearchForSearchCodePaginatesUpToMax(t *testing.T) {
+	client := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			res := model.SearchCodeRes{
+				Results: []model.SearchCodeResult{
+					{Repo: "example/repo", Filename: "file.go", Url: "https://example.test/file.go"},
+				},
+			}
+			return jsonHTTPResponse(http.StatusOK, res), nil
+		}),
+	}
+
+	rule := model.Rule{Content: "key"}
+	results := SearchForSearchCode(rule, client)
+	if len(results) != maxSearchcodePages {
+		t.Fatalf("expected pagination to stop at %d pages, got %d results", maxSearchcodePages, len(results))
+	}
+}

--- a/server/search/scan.go
+++ b/server/search/scan.go
@@ -1,14 +1,36 @@
 package search
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/madneal/gshark/global"
 	"github.com/madneal/gshark/search/codesearch"
 	"github.com/madneal/gshark/search/githubsearch"
 	"github.com/madneal/gshark/search/gitlabsearch"
 	"github.com/madneal/gshark/search/gobuster"
 	"github.com/madneal/gshark/search/postman"
-	"time"
 )
+
+// providerWatchdog bounds how long ScanTask waits for a single provider's
+// RunTask before moving on. It must stay well above the ~900s sleep every
+// RunTask already performs at the end of a normal pass, so healthy runs never
+// trip it. A provider that exceeds this leaks its goroutine (Go cannot force-
+// kill a running goroutine), but the scan loop itself is no longer blocked by it.
+var providerWatchdog = 30 * time.Minute
+
+func runProvider(name string, fn func()) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(providerWatchdog):
+		global.GVA_LOG.Error(fmt.Sprintf("%s scan did not finish within %s, moving on to the next provider", name, providerWatchdog))
+	}
+}
 
 func ScanTask() {
 	for {
@@ -17,10 +39,10 @@ func ScanTask() {
 			return
 		}
 		var Interval time.Duration = 900
-		gitlabsearch.RunTask(Interval)
-		codesearch.RunTask(Interval)
-		githubsearch.RunTask(Interval)
-		gobuster.RunTask(Interval)
-		postman.RunTask()
+		runProvider("gitlab", func() { gitlabsearch.RunTask(Interval) })
+		runProvider("searchcode", func() { codesearch.RunTask(Interval) })
+		runProvider("github", func() { githubsearch.RunTask(Interval) })
+		runProvider("gobuster", func() { gobuster.RunTask(Interval) })
+		runProvider("postman", func() { postman.RunTask() })
 	}
 }

--- a/server/search/scan_test.go
+++ b/server/search/scan_test.go
@@ -1,0 +1,53 @@
+package search
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/madneal/gshark/global"
+	"go.uber.org/zap"
+)
+
+func TestMain(m *testing.M) {
+	global.GVA_LOG = zap.NewNop()
+	os.Exit(m.Run())
+}
+
+func TestRunProviderDoesNotBlockOnSlowFn(t *testing.T) {
+	origWatchdog := providerWatchdog
+	providerWatchdog = 10 * time.Millisecond
+	defer func() { providerWatchdog = origWatchdog }()
+
+	block := make(chan struct{})
+	defer close(block)
+
+	done := make(chan struct{})
+	go func() {
+		runProvider("slow", func() { <-block })
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("runProvider did not return promptly when fn hung past the watchdog")
+	}
+}
+
+func TestRunProviderReturnsPromptlyOnFastFn(t *testing.T) {
+	origWatchdog := providerWatchdog
+	providerWatchdog = 1 * time.Minute
+	defer func() { providerWatchdog = origWatchdog }()
+
+	start := time.Now()
+	ran := false
+	runProvider("fast", func() { ran = true })
+
+	if !ran {
+		t.Fatal("expected fn to run")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("runProvider took too long for a fast fn: %s", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary
- Migrate the Searchcode global-search client off `gorequest` onto a timeout-bound `net/http.Client` (mirrors the existing `postman` package pattern), so a hung/slow request can no longer block forever.
- Fix a nil-pointer-dereference risk in `GetResult`: transport errors (possibly with a `nil` response) now return immediately instead of dereferencing `resp.StatusCode`.
- Return early on non-2xx responses before attempting JSON parsing, and cap pagination at 50 pages as a defensive bound.
- Add a per-provider watchdog around each `RunTask` call in the scan loop (`server/search/scan.go`), sized well above every provider's existing ~900s per-pass sleep baseline, so one stuck provider can no longer starve the rest of the scan cycle.

Fixes #328

## Test plan
- [x] `go build ./...`
- [x] `go vet ./search/...`
- [x] `go test ./...` (full suite passes)
- [x] New unit tests cover: transport error, non-2xx response, invalid JSON, client timeout, bounded pagination, and that the watchdog doesn't block a fast provider or wait forever on a hung one.
- [x] `go mod tidy` confirms only the now-unused `gorequest` dependency (and its transitive-only deps) are removed from `go.mod`/`go.sum`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)