### PR TITLE
feat(scan): add scan log monitoring and per-provider status tracking

### DIFF
--- a/server/api/scan_log.go
+++ b/server/api/scan_log.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/madneal/gshark/global"
+	"github.com/madneal/gshark/model/request"
+	"github.com/madneal/gshark/model/response"
+	"github.com/madneal/gshark/service"
+	"go.uber.org/zap"
+)
+
+func GetScanLogList(c *gin.Context) {
+	var pageInfo request.ScanLogSearch
+	if !bindQuery(c, &pageInfo) {
+		return
+	}
+	err, list, total := service.GetScanLogInfoList(pageInfo)
+	respondPage(c, err, list, total, pageInfo.Page, pageInfo.PageSize)
+}
+
+func GetScanLogOverview(c *gin.Context) {
+	overview, err := service.GetScanLogOverview(time.Now())
+	if err != nil {
+		global.GVA_LOG.Error("get scan log overview failed", zap.Error(err))
+		response.FailWithMessage("获取扫描状态失败", c)
+		return
+	}
+	response.OkWithData(overview, c)
+}

--- a/server/initialize/gorm.go
+++ b/server/initialize/gorm.go
@@ -38,6 +38,7 @@ func MysqlTables(db *gorm.DB) {
 		model.Filter{},
 		model.Repo{},
 		model.Task{},
+		model.ScanLog{},
 	)
 	if err != nil {
 		global.GVA_LOG.Error("register table failed", zap.Any("err", err))

--- a/server/model/request/scan_log.go
+++ b/server/model/request/scan_log.go
@@ -1,0 +1,8 @@
+package request
+
+type ScanLogSearch struct {
+	PageInfo
+	Provider string `json:"provider" form:"provider"`
+	Status   string `json:"status" form:"status"`
+	CycleID  string `json:"cycleId" form:"cycleId"`
+}

--- a/server/model/scan_log.go
+++ b/server/model/scan_log.go
@@ -1,0 +1,53 @@
+package model
+
+import (
+	"time"
+
+	"github.com/madneal/gshark/global"
+)
+
+const (
+	ScanStatusPending     = "pending"
+	ScanStatusRunning     = "running"
+	ScanStatusSuccess     = "success"
+	ScanStatusSkipped     = "skipped"
+	ScanStatusFailed      = "failed"
+	ScanStatusTimeout     = "timeout"
+	ScanStatusInterrupted = "interrupted"
+)
+
+type ScanLog struct {
+	global.GVA_MODEL
+	CycleID         string     `json:"cycleId" gorm:"column:cycle_id;type:varchar(36);index:idx_scan_log_cycle"`
+	Provider        string     `json:"provider" gorm:"column:provider;type:varchar(32);index:idx_scan_log_provider"`
+	Status          string     `json:"status" gorm:"column:status;type:varchar(16);index:idx_scan_log_status"`
+	Message         string     `json:"message" gorm:"column:message;type:varchar(1000)"`
+	ProgressCurrent int        `json:"progressCurrent" gorm:"column:progress_current;default:0"`
+	ProgressTotal   int        `json:"progressTotal" gorm:"column:progress_total;default:1"`
+	StartedAt       *time.Time `json:"startedAt" gorm:"column:started_at"`
+	FinishedAt      *time.Time `json:"finishedAt" gorm:"column:finished_at"`
+	HeartbeatAt     *time.Time `json:"heartbeatAt" gorm:"column:heartbeat_at;index:idx_scan_log_heartbeat"`
+	DurationMs      int64      `json:"durationMs" gorm:"column:duration_ms;default:0"`
+	Stale           bool       `json:"stale" gorm:"-"`
+}
+
+func (ScanLog) TableName() string {
+	return "scan_log"
+}
+
+type ScanOutcome struct {
+	Status  string
+	Message string
+}
+
+func ScanSuccess(message string) ScanOutcome {
+	return ScanOutcome{Status: ScanStatusSuccess, Message: message}
+}
+
+func ScanSkipped(message string) ScanOutcome {
+	return ScanOutcome{Status: ScanStatusSkipped, Message: message}
+}
+
+func ScanFailed(message string) ScanOutcome {
+	return ScanOutcome{Status: ScanStatusFailed, Message: message}
+}

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -43,6 +43,7 @@ func Routers() *gin.Engine {
 		InitSubdomainRouter(PrivateGroup)
 		InitFilterRouter(PrivateGroup)
 		InitRepoRouter(PrivateGroup)
+		InitScanLogRouter(PrivateGroup)
 	}
 	global.GVA_LOG.Info("router register success")
 	return Router

--- a/server/router/scan_log.go
+++ b/server/router/scan_log.go
@@ -1,0 +1,14 @@
+package router
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/madneal/gshark/api"
+)
+
+func InitScanLogRouter(router *gin.RouterGroup) {
+	scanLogRouter := router.Group("scanLog")
+	{
+		scanLogRouter.GET("getScanLogList", api.GetScanLogList)
+		scanLogRouter.GET("getScanLogOverview", api.GetScanLogOverview)
+	}
+}

--- a/server/search/codesearch/search.go
+++ b/server/search/codesearch/search.go
@@ -2,6 +2,7 @@ package codesearch
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -25,23 +26,32 @@ var (
 	searchcodeBaseURL    = "https://searchcode.com/api/codesearch_I/"
 )
 
-func RunTask(duration time.Duration) {
+func RunTask() model.ScanOutcome {
 	err, rules := service.GetValidRulesByType("searchcode")
 	if err != nil {
 		global.GVA_LOG.Error("GetValidRulesByType searchcode err", zap.Error(err))
-		return
+		return model.ScanFailed("Failed to load Searchcode rules: " + err.Error())
 	}
 	if len(rules) == 0 {
-		global.GVA_LOG.Info("Rules of search code is empty")
-		return
+		message := "No enabled Searchcode rules; provider skipped"
+		global.GVA_LOG.Info(message)
+		return model.ScanSkipped(message)
 	}
+	var scanErrors []error
 	for _, rule := range rules {
 		global.GVA_LOG.Info(fmt.Sprintf("Search for %s in searchcode", rule.Content))
-		codeResults := SearchForSearchCode(rule, searchcodeHTTPClient)
+		codeResults, err := SearchForSearchCode(rule, searchcodeHTTPClient)
+		if err != nil {
+			scanErrors = append(scanErrors, fmt.Errorf("search %q: %w", rule.Content, err))
+			continue
+		}
 		SaveResults(codeResults, &rule.Content)
 	}
+	if err := errors.Join(scanErrors...); err != nil {
+		return model.ScanFailed("Searchcode scan completed with errors: " + err.Error())
+	}
 	global.GVA_LOG.Info("Complete the scan of searchcode")
-	time.Sleep(duration * time.Second)
+	return model.ScanSuccess(fmt.Sprintf("Completed %d Searchcode rules", len(rules)))
 }
 
 func SaveResults(results []*model.SearchResult, keyword *string) {
@@ -52,51 +62,58 @@ func SaveResults(results []*model.SearchResult, keyword *string) {
 	global.GVA_LOG.Info(stats.Summary(*keyword, "SearchCode"))
 }
 
-func SearchForSearchCode(rule model.Rule, client *http.Client) []*model.SearchResult {
+func SearchForSearchCode(rule model.Rule, client *http.Client) ([]*model.SearchResult, error) {
 	keyword := rule.Content
 	totalCodeResults := make([]*model.SearchResult, 0)
 	for page := 0; page < maxSearchcodePages; page++ {
 		url := searchcodeBaseURL + "?q=" + keyword + "&p=" + strconv.Itoa(page)
 		global.GVA_LOG.Info("search searchcode result for page " + strconv.Itoa(page))
-		codeResults, hasResult := GetResult(client, url)
+		codeResults, hasResult, err := GetResult(client, url)
+		if err != nil {
+			return totalCodeResults, err
+		}
 		totalCodeResults = append(totalCodeResults, codeResults...)
 		if !hasResult {
 			break
 		}
 	}
-	return totalCodeResults
+	return totalCodeResults, nil
 }
 
-func GetResult(client *http.Client, url string) ([]*model.SearchResult, bool) {
+func GetResult(client *http.Client, url string) ([]*model.SearchResult, bool, error) {
 	codeResults := make([]*model.SearchResult, 0)
 
 	resp, err := client.Get(url)
 	if err != nil || resp == nil {
 		global.GVA_LOG.Error("search result of search code error", zap.Any("err", err))
-		return codeResults, false
+		if err == nil {
+			err = errors.New("Searchcode returned a nil response")
+		}
+		return codeResults, false, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		global.GVA_LOG.Error(fmt.Sprintf("Request to %s error, status code: %d", url, resp.StatusCode))
-		return codeResults, false
+		err = fmt.Errorf("request to %s returned status %d", url, resp.StatusCode)
+		global.GVA_LOG.Error(err.Error())
+		return codeResults, false, err
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		global.GVA_LOG.Error("read searchcode response body err", zap.Error(err))
-		return codeResults, false
+		return codeResults, false, err
 	}
 
 	var result model.SearchCodeRes
 	if jErr := json.Unmarshal(body, &result); jErr != nil {
 		global.GVA_LOG.Error("json unmarshal searchCodeRes err", zap.Error(jErr))
-		return codeResults, false
+		return codeResults, false, jErr
 	}
 
 	results := result.Results
 	if len(results) == 0 {
-		return codeResults, false
+		return codeResults, false, nil
 	}
 	for _, val := range results {
 		if strings.Contains(val.Repo, "github") {
@@ -122,5 +139,5 @@ func GetResult(client *http.Client, url string) ([]*model.SearchResult, bool) {
 		}
 		codeResults = append(codeResults, &codeResult)
 	}
-	return codeResults, true
+	return codeResults, true, nil
 }

--- a/server/search/codesearch/search_test.go
+++ b/server/search/codesearch/search_test.go
@@ -44,7 +44,10 @@ func TestGetResultHandlesTransportError(t *testing.T) {
 		}),
 	}
 
-	results, hasResult := GetResult(client, "https://searchcode.test/api/codesearch_I/?q=key&p=0")
+	results, hasResult, err := GetResult(client, "https://searchcode.test/api/codesearch_I/?q=key&p=0")
+	if err == nil {
+		t.Fatal("expected a transport error")
+	}
 	if hasResult {
 		t.Fatalf("expected hasResult=false on transport error")
 	}
@@ -60,7 +63,10 @@ func TestGetResultReturnsNoResultsOnNon2xx(t *testing.T) {
 		}),
 	}
 
-	results, hasResult := GetResult(client, "https://searchcode.test/api/codesearch_I/?q=key&p=0")
+	results, hasResult, err := GetResult(client, "https://searchcode.test/api/codesearch_I/?q=key&p=0")
+	if err == nil {
+		t.Fatal("expected a non-2xx error")
+	}
 	if hasResult {
 		t.Fatalf("expected hasResult=false on non-2xx response")
 	}
@@ -80,7 +86,10 @@ func TestGetResultStopsOnInvalidJSON(t *testing.T) {
 		}),
 	}
 
-	results, hasResult := GetResult(client, "https://searchcode.test/api/codesearch_I/?q=key&p=0")
+	results, hasResult, err := GetResult(client, "https://searchcode.test/api/codesearch_I/?q=key&p=0")
+	if err == nil {
+		t.Fatal("expected an invalid JSON error")
+	}
 	if hasResult {
 		t.Fatalf("expected hasResult=false on invalid JSON")
 	}
@@ -101,7 +110,7 @@ func TestGetResultRespectsTimeout(t *testing.T) {
 	done := make(chan struct{})
 	var hasResult bool
 	go func() {
-		_, hasResult = GetResult(client, server.URL)
+		_, hasResult, _ = GetResult(client, server.URL)
 		close(done)
 	}()
 
@@ -128,7 +137,10 @@ func TestSearchForSearchCodePaginatesUpToMax(t *testing.T) {
 	}
 
 	rule := model.Rule{Content: "key"}
-	results := SearchForSearchCode(rule, client)
+	results, err := SearchForSearchCode(rule, client)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(results) != maxSearchcodePages {
 		t.Fatalf("expected pagination to stop at %d pages, got %d results", maxSearchcodePages, len(results))
 	}

--- a/server/search/githubsearch/search.go
+++ b/server/search/githubsearch/search.go
@@ -18,25 +18,28 @@ import (
 	"time"
 )
 
-func Search(rules []model.Rule) {
+func Search(rules []model.Rule) error {
 	if len(rules) == 0 {
-		return
+		return nil
 	}
 	client, err := GetGithubClient()
 	if err != nil {
 		global.GVA_LOG.Error("GetGithubClient err", zap.Error(err))
-		return
+		return err
 	}
 	var content string
+	var scanErrors []error
 	for _, rule := range rules {
 		query, err := BuildQuery(rule.Content)
 		if err != nil {
 			global.GVA_LOG.Error("BuildQuery error", zap.Error(err))
+			scanErrors = append(scanErrors, fmt.Errorf("build query for %q: %w", rule.Content, err))
 			continue
 		}
 		results, err := client.SearchCode(query)
 		if err != nil {
 			global.GVA_LOG.Error("SearchCode error", zap.Error(err))
+			scanErrors = append(scanErrors, fmt.Errorf("search %q: %w", rule.Content, err))
 			continue
 		}
 		stats := SaveResultWithStats(results, rule.Content)
@@ -68,6 +71,7 @@ func Search(rules []model.Rule) {
 			}
 		}
 	}
+	return errors.Join(scanErrors...)
 }
 
 func SaveResultWithStats(results []*github.CodeSearchResult, keyword string) *service.SaveResultStats {
@@ -101,16 +105,23 @@ func ConvertToSearchResults(results []*github.CodeSearchResult, keyword string) 
 	return searchResults
 }
 
-func RunTask(duration time.Duration) {
-	err, rules := service.GetValidRulesByType("github")
+func RunTask() model.ScanOutcome {
+	err, rules := getGithubRules("github")
 	if err != nil {
 		global.GVA_LOG.Error("GetValidRulesByType github err", zap.Error(err))
-		return
+		return model.ScanFailed("Failed to load GitHub rules: " + err.Error())
 	}
 	color.Debug.Print(fmt.Sprintf("Github fetch %d rules, begin the scan task\n", len(rules)))
-	Search(rules)
-	color.Debug.Print(fmt.Sprintf("Comple the scan of Github, start to sleep %d seconds", duration))
-	time.Sleep(duration * time.Second)
+	if len(rules) == 0 {
+		message := "No enabled GitHub rules; provider skipped"
+		global.GVA_LOG.Info(message)
+		return model.ScanSkipped(message)
+	}
+	if err := Search(rules); err != nil {
+		return model.ScanFailed("GitHub scan completed with errors: " + err.Error())
+	}
+	color.Debug.Print("Complete the scan of Github\n")
+	return model.ScanSuccess(fmt.Sprintf("Completed %d GitHub rules", len(rules)))
 }
 
 func (c *Client) GetCommiter(ctx context.Context, owner, repo string) string {
@@ -131,9 +142,11 @@ func (c *Client) SearchCode(query string) ([]*github.CodeSearchResult, error) {
 	global.GVA_LOG.Info("Github scan with the query:", zap.Any("github", query))
 	for {
 		result, nextPage := c.searchCodeByOpt(ctx, query, *opt)
-		if result != nil {
-			allSearchResult = append(allSearchResult, result)
+		if result == nil {
+			err = fmt.Errorf("GitHub returned no response for query %q", query)
+			break
 		}
+		allSearchResult = append(allSearchResult, result)
 		if nextPage <= 0 {
 			break
 		}
@@ -190,6 +203,8 @@ const maxSearchAttempts = 3
 
 // sleepFn is overridden in tests so rate-limit backoffs don't actually block.
 var sleepFn = time.Sleep
+
+var getGithubRules = service.GetValidRulesByType
 
 func (c *Client) searchCodeByOpt(ctx context.Context, query string, opt github.SearchOptions) (*github.CodeSearchResult,
 	int) {

--- a/server/search/githubsearch/search_test.go
+++ b/server/search/githubsearch/search_test.go
@@ -41,6 +41,21 @@ func TestSearchWithNoRules(t *testing.T) {
 	Search(nil)
 }
 
+func TestRunTaskWithoutRulesDoesNotSleep(t *testing.T) {
+	originalRules := getGithubRules
+	getGithubRules = func(string) (error, []model.Rule) { return nil, nil }
+	t.Cleanup(func() { getGithubRules = originalRules })
+
+	slept := stubSleep(t)
+	outcome := RunTask()
+	if len(*slept) != 0 {
+		t.Fatalf("RunTask slept without GitHub rules: %v", *slept)
+	}
+	if outcome.Status != model.ScanStatusSkipped {
+		t.Fatalf("outcome status = %q, want skipped", outcome.Status)
+	}
+}
+
 func newTestClient(t *testing.T, handler http.HandlerFunc) (*Client, func() *github.Client) {
 	t.Helper()
 	server := httptest.NewServer(handler)

--- a/server/search/gitlabsearch/search.go
+++ b/server/search/gitlabsearch/search.go
@@ -27,31 +27,38 @@ const (
 	maxConcurrentProjectSearches = 5
 )
 
-func RunTask(duration time.Duration) {
-	client := GetClient()
+var (
+	getGitlabClient = GetClient
+	getGitlabRules  = service.GetValidRulesByType
+)
+
+func RunTask() model.ScanOutcome {
+	client := getGitlabClient()
 	if client == nil {
-		color.Warnln("There is no client for Gitlab, please check if you specify Gitlab token")
-		time.Sleep(duration * time.Second)
-		return
+		message := "There is no client for GitLab; configure a GitLab token to enable this provider"
+		color.Warnln(message)
+		return model.ScanSkipped(message)
 	}
 
-	err, rules := service.GetValidRulesByType("gitlab")
+	err, rules := getGitlabRules("gitlab")
 	if err != nil {
 		global.GVA_LOG.Error("GetValidRulesByType gitlab err", zap.Error(err))
-		return
+		return model.ScanFailed("Failed to load GitLab rules: " + err.Error())
 	}
 	if len(rules) == 0 {
-		time.Sleep(duration * time.Second)
-		return
+		message := "No enabled GitLab rules; provider skipped"
+		global.GVA_LOG.Info(message)
+		return model.ScanSkipped(message)
 	}
 
 	if !RunGlobalSearchTask(client, rules) {
 		global.GVA_LOG.Info("GitLab global blob search unavailable (no Advanced Search), falling back to per-project crawl")
 		GetProjects(client, discoverPages())
 		RunSearchTaskByProject(NextProjectBatch(batchSize()), rules, client)
+		return model.ScanSuccess(fmt.Sprintf("Completed %d GitLab rules with per-project fallback", len(rules)))
 	}
-	global.GVA_LOG.Info(fmt.Sprintf("Complete the scan of GitLab, start to sleep %d seconds", duration))
-	time.Sleep(duration * time.Second)
+	global.GVA_LOG.Info("Complete the scan of GitLab")
+	return model.ScanSuccess(fmt.Sprintf("Completed %d GitLab rules", len(rules)))
 }
 
 func discoverPages() int {

--- a/server/search/gitlabsearch/search_test.go
+++ b/server/search/gitlabsearch/search_test.go
@@ -16,6 +16,35 @@ import (
 	"go.uber.org/zap"
 )
 
+func TestRunTaskWithoutClientDoesNotSleep(t *testing.T) {
+	originalClient := getGitlabClient
+	getGitlabClient = func() *gitlab.Client { return nil }
+	t.Cleanup(func() {
+		getGitlabClient = originalClient
+	})
+
+	outcome := RunTask()
+	if outcome.Status != model.ScanStatusSkipped {
+		t.Fatalf("outcome status = %q, want skipped", outcome.Status)
+	}
+}
+
+func TestRunTaskWithoutRulesDoesNotSleep(t *testing.T) {
+	originalClient := getGitlabClient
+	originalRules := getGitlabRules
+	getGitlabClient = func() *gitlab.Client { return &gitlab.Client{} }
+	getGitlabRules = func(string) (error, []model.Rule) { return nil, nil }
+	t.Cleanup(func() {
+		getGitlabClient = originalClient
+		getGitlabRules = originalRules
+	})
+
+	outcome := RunTask()
+	if outcome.Status != model.ScanStatusSkipped {
+		t.Fatalf("outcome status = %q, want skipped", outcome.Status)
+	}
+}
+
 func TestMain(m *testing.M) {
 	global.GVA_LOG = zap.NewNop()
 	os.Exit(m.Run())

--- a/server/search/gobuster/dns.go
+++ b/server/search/gobuster/dns.go
@@ -113,17 +113,22 @@ func run(ctx context.Context, word, domain string) error {
 	return err
 }
 
-func RunTask(duration time.Duration) {
+func RunTask() model.ScanOutcome {
 	err, rules := service.GetValidRulesByType("domain")
 	if err != nil {
 		global.GVA_LOG.Error("get subdomain rules error", zap.Any("error", err))
+		return model.ScanFailed("Failed to load domain rules: " + err.Error())
+	}
+	if len(rules) == 0 {
+		message := "No enabled domain rules; provider skipped"
+		global.GVA_LOG.Info(message)
+		return model.ScanSkipped(message)
 	}
 	for _, rule := range rules {
 		start := time.Now()
 		domain := rule.Content
 		RunDNS(context.Background(), domain)
-		fmt.Printf("Complete the scan of domain %s, cost %v, start to sleep %v seconds",
-			domain, time.Since(start), duration*time.Second)
-		time.Sleep(duration * time.Second)
+		fmt.Printf("Complete the scan of domain %s, cost %v\n", domain, time.Since(start))
 	}
+	return model.ScanSuccess(fmt.Sprintf("Completed %d domain rules", len(rules)))
 }

--- a/server/search/postman/search.go
+++ b/server/search/postman/search.go
@@ -3,6 +3,7 @@ package postman
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -25,6 +26,11 @@ const (
 )
 
 var postmanHTTPClient = &http.Client{Timeout: postmanRequestTimeout}
+
+var (
+	getPostmanRules = service.GetValidRulesByType
+	searchPostman   = Search
+)
 
 type PostmanResourceRef struct {
 	ID   string `json:"id"`
@@ -68,25 +74,36 @@ type PostmanRes struct {
 	} `json:"meta"`
 }
 
-func RunTask() {
-	err, rules := service.GetValidRulesByType("postman")
+func RunTask() model.ScanOutcome {
+	err, rules := getPostmanRules("postman")
 	if err != nil {
 		global.GVA_LOG.Error("GetValidRulesByType postman err", zap.Error(err))
-		return
+		return model.ScanFailed("Failed to load Postman rules: " + err.Error())
+	}
+	if len(rules) == 0 {
+		message := "No enabled Postman rules; provider skipped"
+		global.GVA_LOG.Info(message)
+		return model.ScanSkipped(message)
 	}
 	color.Infoln("begin the postman search task")
-	Search(&rules)
-	color.Infof("finish the postman search task, ready to sleep\n")
-	time.Sleep(900 * time.Second)
-}
-
-func Search(rules *[]model.Rule) {
-	for _, rule := range *rules {
-		SearchByType(rule.Content, "request")
+	if err := searchPostman(&rules); err != nil {
+		return model.ScanFailed("Postman scan completed with errors: " + err.Error())
 	}
+	color.Infof("finish the postman search task\n")
+	return model.ScanSuccess(fmt.Sprintf("Completed %d Postman rules", len(rules)))
 }
 
-func SearchByType(keyword, searchType string) {
+func Search(rules *[]model.Rule) error {
+	var searchErrors []error
+	for _, rule := range *rules {
+		if err := SearchByType(rule.Content, "request"); err != nil {
+			searchErrors = append(searchErrors, err)
+		}
+	}
+	return errors.Join(searchErrors...)
+}
+
+func SearchByType(keyword, searchType string) error {
 	resList, err := SearchAPI(keyword, searchType)
 	for _, res := range *resList {
 		results := res.ConvertToSearchResult(keyword)
@@ -96,6 +113,7 @@ func SearchByType(keyword, searchType string) {
 	if err != nil {
 		global.GVA_LOG.Error("postman SearchAPI err", zap.Error(err))
 	}
+	return err
 }
 
 func (res *PostmanRes) ConvertToSearchResult(keyword string) *[]model.SearchResult {

--- a/server/search/postman/search_test.go
+++ b/server/search/postman/search_test.go
@@ -14,7 +14,31 @@ import (
 
 	"github.com/madneal/gshark/global"
 	"github.com/madneal/gshark/initialize"
+	"github.com/madneal/gshark/model"
+	"go.uber.org/zap"
 )
+
+func TestRunTaskWithoutRulesDoesNotSleepOrSearch(t *testing.T) {
+	originalLog := global.GVA_LOG
+	originalRules := getPostmanRules
+	originalSearch := searchPostman
+	global.GVA_LOG = zap.NewNop()
+	getPostmanRules = func(string) (error, []model.Rule) { return nil, nil }
+	searchPostman = func(*[]model.Rule) error {
+		t.Fatal("RunTask searched without Postman rules")
+		return nil
+	}
+	t.Cleanup(func() {
+		global.GVA_LOG = originalLog
+		getPostmanRules = originalRules
+		searchPostman = originalSearch
+	})
+
+	outcome := RunTask()
+	if outcome.Status != model.ScanStatusSkipped {
+		t.Fatalf("outcome status = %q, want skipped", outcome.Status)
+	}
+}
 
 func TestRunTask(t *testing.T) {
 	if testing.Short() {

--- a/server/search/scan.go
+++ b/server/search/scan.go
@@ -2,47 +2,125 @@ package search
 
 import (
 	"fmt"
+	"runtime/debug"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/madneal/gshark/global"
+	"github.com/madneal/gshark/model"
 	"github.com/madneal/gshark/search/codesearch"
 	"github.com/madneal/gshark/search/githubsearch"
 	"github.com/madneal/gshark/search/gitlabsearch"
 	"github.com/madneal/gshark/search/gobuster"
 	"github.com/madneal/gshark/search/postman"
+	"github.com/madneal/gshark/service"
+	"go.uber.org/zap"
 )
 
-// providerWatchdog bounds how long ScanTask waits for a single provider's
-// RunTask before moving on. It must stay well above the ~900s sleep every
-// RunTask already performs at the end of a normal pass, so healthy runs never
-// trip it. A provider that exceeds this leaks its goroutine (Go cannot force-
-// kill a running goroutine), but the scan loop itself is no longer blocked by it.
-var providerWatchdog = 30 * time.Minute
+var (
+	providerWatchdog        = 30 * time.Minute
+	providerHeartbeat       = 10 * time.Second
+	scanInterval            = 15 * time.Minute
+	createScanCycle         = service.CreateScanCycle
+	startScanLog            = service.StartScanLog
+	heartbeatScanLog        = service.HeartbeatScanLog
+	finishScanLog           = service.FinishScanLog
+	markInterruptedScanLogs = service.MarkInterruptedScanLogs
+	scanSleep               = time.Sleep
+)
 
-func runProvider(name string, fn func()) {
-	done := make(chan struct{})
+type providerTask struct {
+	name string
+	run  func() model.ScanOutcome
+}
+
+func runProvider(logID uint, name string, fn func() model.ScanOutcome) model.ScanOutcome {
+	startedAt := time.Now()
+	if err := startScanLog(logID, startedAt); err != nil {
+		global.GVA_LOG.Error("start scan log failed", zap.String("provider", name), zap.Error(err))
+	}
+
+	done := make(chan model.ScanOutcome, 1)
 	go func() {
-		defer close(done)
-		fn()
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				global.GVA_LOG.Error("scan provider panicked", zap.String("provider", name), zap.Any("panic", recovered), zap.ByteString("stack", debug.Stack()))
+				done <- model.ScanFailed(fmt.Sprintf("Provider panicked: %v", recovered))
+			}
+		}()
+		done <- fn()
 	}()
-	select {
-	case <-done:
-	case <-time.After(providerWatchdog):
-		global.GVA_LOG.Error(fmt.Sprintf("%s scan did not finish within %s, moving on to the next provider", name, providerWatchdog))
+
+	watchdog := time.NewTimer(providerWatchdog)
+	heartbeat := time.NewTicker(providerHeartbeat)
+	defer watchdog.Stop()
+	defer heartbeat.Stop()
+
+	var outcome model.ScanOutcome
+	for {
+		select {
+		case outcome = <-done:
+			if outcome.Status == "" {
+				outcome = model.ScanSuccess("Scan completed")
+			}
+			goto Finished
+		case heartbeatAt := <-heartbeat.C:
+			if err := heartbeatScanLog(logID, heartbeatAt); err != nil {
+				global.GVA_LOG.Error("update scan heartbeat failed", zap.String("provider", name), zap.Error(err))
+			}
+		case <-watchdog.C:
+			message := fmt.Sprintf("Scan did not finish within %s", providerWatchdog)
+			global.GVA_LOG.Error(fmt.Sprintf("%s %s, moving on to the next provider", name, message))
+			outcome = model.ScanOutcome{Status: model.ScanStatusTimeout, Message: message}
+			goto Finished
+		}
+	}
+
+Finished:
+	finishedAt := time.Now()
+	if err := finishScanLog(logID, outcome, startedAt, finishedAt); err != nil {
+		global.GVA_LOG.Error("finish scan log failed", zap.String("provider", name), zap.Error(err))
+	}
+	return outcome
+}
+
+func scanTasks() []providerTask {
+	return []providerTask{
+		{name: "gitlab", run: gitlabsearch.RunTask},
+		{name: "searchcode", run: codesearch.RunTask},
+		{name: "github", run: githubsearch.RunTask},
+		{name: "gobuster", run: gobuster.RunTask},
+		{name: "postman", run: postman.RunTask},
+	}
+}
+
+func runScanCycle() {
+	tasks := scanTasks()
+	providers := make([]string, 0, len(tasks))
+	for _, task := range tasks {
+		providers = append(providers, task.name)
+	}
+	cycleID := uuid.NewString()
+	logIDs, err := createScanCycle(cycleID, providers)
+	if err != nil {
+		global.GVA_LOG.Error("create scan cycle failed", zap.String("cycleId", cycleID), zap.Error(err))
+		logIDs = map[string]uint{}
+	}
+	for _, task := range tasks {
+		runProvider(logIDs[task.name], task.name, task.run)
 	}
 }
 
 func ScanTask() {
+	if global.GVA_DB == nil {
+		global.GVA_LOG.Info("have not init db")
+		return
+	}
+	if err := markInterruptedScanLogs(time.Now()); err != nil {
+		global.GVA_LOG.Error("mark interrupted scan logs failed", zap.Error(err))
+	}
 	for {
-		if global.GVA_DB == nil {
-			global.GVA_LOG.Info("have not init db")
-			return
-		}
-		var Interval time.Duration = 900
-		runProvider("gitlab", func() { gitlabsearch.RunTask(Interval) })
-		runProvider("searchcode", func() { codesearch.RunTask(Interval) })
-		runProvider("github", func() { githubsearch.RunTask(Interval) })
-		runProvider("gobuster", func() { gobuster.RunTask(Interval) })
-		runProvider("postman", func() { postman.RunTask() })
+		runScanCycle()
+		scanSleep(scanInterval)
 	}
 }

--- a/server/search/scan_test.go
+++ b/server/search/scan_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/madneal/gshark/global"
+	"github.com/madneal/gshark/model"
 	"go.uber.org/zap"
 )
 
@@ -15,16 +16,30 @@ func TestMain(m *testing.M) {
 }
 
 func TestRunProviderDoesNotBlockOnSlowFn(t *testing.T) {
+	stubScanLogPersistence(t)
+	var finished model.ScanOutcome
+	finishScanLog = func(_ uint, outcome model.ScanOutcome, _, _ time.Time) error {
+		finished = outcome
+		return nil
+	}
 	origWatchdog := providerWatchdog
+	origHeartbeat := providerHeartbeat
 	providerWatchdog = 10 * time.Millisecond
-	defer func() { providerWatchdog = origWatchdog }()
+	providerHeartbeat = time.Millisecond
+	defer func() {
+		providerWatchdog = origWatchdog
+		providerHeartbeat = origHeartbeat
+	}()
 
 	block := make(chan struct{})
 	defer close(block)
 
 	done := make(chan struct{})
 	go func() {
-		runProvider("slow", func() { <-block })
+		runProvider(1, "slow", func() model.ScanOutcome {
+			<-block
+			return model.ScanSuccess("done")
+		})
 		close(done)
 	}()
 
@@ -33,16 +48,28 @@ func TestRunProviderDoesNotBlockOnSlowFn(t *testing.T) {
 	case <-time.After(1 * time.Second):
 		t.Fatal("runProvider did not return promptly when fn hung past the watchdog")
 	}
+	if finished.Status != model.ScanStatusTimeout {
+		t.Fatalf("finished status = %q, want timeout", finished.Status)
+	}
 }
 
 func TestRunProviderReturnsPromptlyOnFastFn(t *testing.T) {
+	stubScanLogPersistence(t)
 	origWatchdog := providerWatchdog
+	origHeartbeat := providerHeartbeat
 	providerWatchdog = 1 * time.Minute
-	defer func() { providerWatchdog = origWatchdog }()
+	providerHeartbeat = time.Minute
+	defer func() {
+		providerWatchdog = origWatchdog
+		providerHeartbeat = origHeartbeat
+	}()
 
 	start := time.Now()
 	ran := false
-	runProvider("fast", func() { ran = true })
+	outcome := runProvider(1, "fast", func() model.ScanOutcome {
+		ran = true
+		return model.ScanSuccess("done")
+	})
 
 	if !ran {
 		t.Fatal("expected fn to run")
@@ -50,4 +77,36 @@ func TestRunProviderReturnsPromptlyOnFastFn(t *testing.T) {
 	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
 		t.Fatalf("runProvider took too long for a fast fn: %s", elapsed)
 	}
+	if outcome.Status != model.ScanStatusSuccess {
+		t.Fatalf("unexpected outcome: %#v", outcome)
+	}
+}
+
+func TestRunProviderRecordsPanicAsFailure(t *testing.T) {
+	stubScanLogPersistence(t)
+	origHeartbeat := providerHeartbeat
+	providerHeartbeat = time.Minute
+	defer func() { providerHeartbeat = origHeartbeat }()
+
+	outcome := runProvider(1, "panic", func() model.ScanOutcome {
+		panic("boom")
+	})
+	if outcome.Status != model.ScanStatusFailed {
+		t.Fatalf("outcome status = %q, want %q", outcome.Status, model.ScanStatusFailed)
+	}
+}
+
+func stubScanLogPersistence(t *testing.T) {
+	t.Helper()
+	originalStart := startScanLog
+	originalHeartbeat := heartbeatScanLog
+	originalFinish := finishScanLog
+	startScanLog = func(uint, time.Time) error { return nil }
+	heartbeatScanLog = func(uint, time.Time) error { return nil }
+	finishScanLog = func(uint, model.ScanOutcome, time.Time, time.Time) error { return nil }
+	t.Cleanup(func() {
+		startScanLog = originalStart
+		heartbeatScanLog = originalHeartbeat
+		finishScanLog = originalFinish
+	})
 }

--- a/server/service/scan_log.go
+++ b/server/service/scan_log.go
@@ -1,0 +1,166 @@
+package service
+
+import (
+	"time"
+
+	"github.com/madneal/gshark/global"
+	"github.com/madneal/gshark/model"
+	"github.com/madneal/gshark/model/request"
+	"gorm.io/gorm"
+)
+
+const scanHeartbeatStaleAfter = 45 * time.Second
+
+type ScanLogOverview struct {
+	CycleID        string          `json:"cycleId"`
+	Logs           []model.ScanLog `json:"logs"`
+	Total          int             `json:"total"`
+	Completed      int             `json:"completed"`
+	Running        int             `json:"running"`
+	Abnormal       int             `json:"abnormal"`
+	Progress       int             `json:"progress"`
+	LastActivityAt *time.Time      `json:"lastActivityAt"`
+}
+
+func CreateScanCycle(cycleID string, providers []string) (map[string]uint, error) {
+	ids := make(map[string]uint, len(providers))
+	err := global.GVA_DB.Transaction(func(tx *gorm.DB) error {
+		for _, provider := range providers {
+			logEntry := model.ScanLog{
+				CycleID:       cycleID,
+				Provider:      provider,
+				Status:        model.ScanStatusPending,
+				Message:       "Waiting for the previous provider to finish",
+				ProgressTotal: 1,
+			}
+			if err := tx.Create(&logEntry).Error; err != nil {
+				return err
+			}
+			ids[provider] = logEntry.ID
+		}
+		return nil
+	})
+	return ids, err
+}
+
+func StartScanLog(id uint, startedAt time.Time) error {
+	if id == 0 {
+		return nil
+	}
+	return global.GVA_DB.Model(&model.ScanLog{}).Where("id = ?", id).Updates(map[string]interface{}{
+		"status":           model.ScanStatusRunning,
+		"message":          "Scan is running",
+		"started_at":       startedAt,
+		"heartbeat_at":     startedAt,
+		"progress_current": 0,
+	}).Error
+}
+
+func HeartbeatScanLog(id uint, heartbeatAt time.Time) error {
+	if id == 0 {
+		return nil
+	}
+	return global.GVA_DB.Model(&model.ScanLog{}).Where("id = ? AND status = ?", id, model.ScanStatusRunning).
+		Updates(map[string]interface{}{"heartbeat_at": heartbeatAt, "updated_at": heartbeatAt}).Error
+}
+
+func FinishScanLog(id uint, outcome model.ScanOutcome, startedAt, finishedAt time.Time) error {
+	if id == 0 {
+		return nil
+	}
+	return global.GVA_DB.Model(&model.ScanLog{}).Where("id = ?", id).Updates(map[string]interface{}{
+		"status":           outcome.Status,
+		"message":          outcome.Message,
+		"finished_at":      finishedAt,
+		"heartbeat_at":     finishedAt,
+		"duration_ms":      finishedAt.Sub(startedAt).Milliseconds(),
+		"progress_current": 1,
+	}).Error
+}
+
+func MarkInterruptedScanLogs(interruptedAt time.Time) error {
+	return global.GVA_DB.Model(&model.ScanLog{}).
+		Where("status IN ?", []string{model.ScanStatusPending, model.ScanStatusRunning}).
+		Updates(map[string]interface{}{
+			"status":       model.ScanStatusInterrupted,
+			"message":      "Scanner stopped before this task completed",
+			"finished_at":  interruptedAt,
+			"heartbeat_at": interruptedAt,
+		}).Error
+}
+
+func GetScanLogInfoList(info request.ScanLogSearch) (error, interface{}, int64) {
+	db := global.GVA_DB.Model(&model.ScanLog{})
+	var logs []model.ScanLog
+	if info.Provider != "" {
+		db = db.Where("provider = ?", info.Provider)
+	}
+	if info.Status != "" {
+		db = db.Where("status = ?", info.Status)
+	}
+	if info.CycleID != "" {
+		db = db.Where("cycle_id = ?", info.CycleID)
+	}
+	total, err := Paginate(db, info.Page, info.PageSize, &logs, "id desc")
+	markStaleScanLogs(logs, time.Now())
+	return err, logs, total
+}
+
+func GetScanLogOverview(now time.Time) (ScanLogOverview, error) {
+	var latest model.ScanLog
+	if err := global.GVA_DB.Order("id desc").First(&latest).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return ScanLogOverview{Logs: []model.ScanLog{}}, nil
+		}
+		return ScanLogOverview{}, err
+	}
+
+	var logs []model.ScanLog
+	if err := global.GVA_DB.Where("cycle_id = ?", latest.CycleID).Order("id asc").Find(&logs).Error; err != nil {
+		return ScanLogOverview{}, err
+	}
+	return buildScanLogOverview(latest.CycleID, logs, now), nil
+}
+
+func buildScanLogOverview(cycleID string, logs []model.ScanLog, now time.Time) ScanLogOverview {
+	overview := ScanLogOverview{CycleID: cycleID, Logs: logs}
+	markStaleScanLogs(overview.Logs, now)
+	overview.Total = len(overview.Logs)
+	for i := range overview.Logs {
+		entry := overview.Logs[i]
+		if entry.Status == model.ScanStatusRunning {
+			overview.Running++
+		}
+		if entry.Status != model.ScanStatusPending && entry.Status != model.ScanStatusRunning {
+			overview.Completed++
+		}
+		if entry.Stale || isAbnormalScanStatus(entry.Status) {
+			overview.Abnormal++
+		}
+		activityAt := entry.UpdatedAt
+		if entry.HeartbeatAt != nil {
+			activityAt = *entry.HeartbeatAt
+		}
+		if overview.LastActivityAt == nil || activityAt.After(*overview.LastActivityAt) {
+			activity := activityAt
+			overview.LastActivityAt = &activity
+		}
+	}
+	if overview.Total > 0 {
+		overview.Progress = overview.Completed * 100 / overview.Total
+	}
+	return overview
+}
+
+func markStaleScanLogs(logs []model.ScanLog, now time.Time) {
+	for i := range logs {
+		if logs[i].Status != model.ScanStatusRunning || logs[i].HeartbeatAt == nil {
+			continue
+		}
+		logs[i].Stale = now.Sub(*logs[i].HeartbeatAt) > scanHeartbeatStaleAfter
+	}
+}
+
+func isAbnormalScanStatus(status string) bool {
+	return status == model.ScanStatusFailed || status == model.ScanStatusTimeout || status == model.ScanStatusInterrupted
+}

--- a/server/service/scan_log_test.go
+++ b/server/service/scan_log_test.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/madneal/gshark/model"
+)
+
+func TestBuildScanLogOverviewSummarizesCycle(t *testing.T) {
+	now := time.Now()
+	recent := now.Add(-time.Second)
+	finished := now.Add(-2 * time.Second)
+	logs := []model.ScanLog{
+		{Provider: "gitlab", Status: model.ScanStatusSuccess, FinishedAt: &finished, HeartbeatAt: &finished},
+		{Provider: "github", Status: model.ScanStatusRunning, HeartbeatAt: &recent},
+		{Provider: "postman", Status: model.ScanStatusPending},
+	}
+
+	overview := buildScanLogOverview("cycle-1", logs, now)
+	if overview.Total != 3 || overview.Completed != 1 || overview.Running != 1 {
+		t.Fatalf("unexpected counts: %#v", overview)
+	}
+	if overview.Progress != 33 {
+		t.Fatalf("progress = %d, want 33", overview.Progress)
+	}
+	if overview.Abnormal != 0 {
+		t.Fatalf("abnormal = %d, want 0", overview.Abnormal)
+	}
+}
+
+func TestBuildScanLogOverviewDetectsStaleAndFailedTasks(t *testing.T) {
+	now := time.Now()
+	staleHeartbeat := now.Add(-scanHeartbeatStaleAfter - time.Second)
+	logs := []model.ScanLog{
+		{Provider: "github", Status: model.ScanStatusRunning, HeartbeatAt: &staleHeartbeat},
+		{Provider: "postman", Status: model.ScanStatusFailed},
+	}
+
+	overview := buildScanLogOverview("cycle-2", logs, now)
+	if !overview.Logs[0].Stale {
+		t.Fatal("expected running task with an old heartbeat to be marked stale")
+	}
+	if overview.Abnormal != 2 {
+		t.Fatalf("abnormal = %d, want 2", overview.Abnormal)
+	}
+}

--- a/server/service/sys_initdb.go
+++ b/server/service/sys_initdb.go
@@ -136,6 +136,7 @@ func InitDB(conf request.InitDB) error {
 		model.Filter{},
 		model.Repo{},
 		model.Task{},
+		model.ScanLog{},
 	)
 	if err != nil {
 		return err

--- a/server/source/api.go
+++ b/server/source/api.go
@@ -109,6 +109,8 @@ var apis = []model.SysApi{
 	{global.GVA_MODEL{CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/repo/updateRepo", "更新仓库", "repo", "PUT"},
 	{global.GVA_MODEL{CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/repo/findRepo", "根据ID获取仓库", "repo", "GET"},
 	{global.GVA_MODEL{CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/repo/getRepoList", "获取仓库列表", "repo", "GET"},
+	{global.GVA_MODEL{CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/scanLog/getScanLogList", "获取扫描日志列表", "scanLog", "GET"},
+	{global.GVA_MODEL{CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/scanLog/getScanLogOverview", "获取扫描状态概览", "scanLog", "GET"},
 }
 
 func (a *api) Init() error {

--- a/server/source/authorities_menus.go
+++ b/server/source/authorities_menus.go
@@ -46,6 +46,7 @@ var authorityMenus = []AuthorityMenus{
 	{"888", 28},
 	{"888", 29},
 	{"888", 30},
+	{"888", 31},
 	{"8881", 1},
 	{"8881", 2},
 	{"8881", 8},
@@ -69,7 +70,7 @@ var authorityMenus = []AuthorityMenus{
 
 func (a *authoritiesMenus) Init() error {
 	return global.GVA_DB.Table("sys_authority_menus").Transaction(func(tx *gorm.DB) error {
-		if tx.Where("sys_authority_authority_id IN ('888', '8881', '9528')").Find(&[]AuthorityMenus{}).RowsAffected == 48 {
+		if tx.Where("sys_authority_authority_id IN ('888', '8881', '9528')").Find(&[]AuthorityMenus{}).RowsAffected == 49 {
 			color.Danger.Println("\n[Mysql] --> sys_authority_menus 表的初始数据已存在!")
 			return nil
 		}

--- a/server/source/casbin.go
+++ b/server/source/casbin.go
@@ -106,6 +106,8 @@ var carbines = []gormadapter.CasbinRule{
 	{PType: "p", V0: "888", V1: "/repo/updateRepo", V2: "PUT"},
 	{PType: "p", V0: "888", V1: "/repo/findRepo", V2: "GET"},
 	{PType: "p", V0: "888", V1: "/repo/getRepoList", V2: "GET"},
+	{PType: "p", V0: "888", V1: "/scanLog/getScanLogList", V2: "GET"},
+	{PType: "p", V0: "888", V1: "/scanLog/getScanLogOverview", V2: "GET"},
 }
 
 func (c *casbin) Init() error {

--- a/server/source/menu.go
+++ b/server/source/menu.go
@@ -33,11 +33,12 @@ var menus = []model.SysBaseMenu{
 	{GVA_MODEL: global.GVA_MODEL{ID: 2, CreatedAt: time.Now(), UpdatedAt: time.Now()}, MenuLevel: 0, ParentId: "24", Path: "token", Name: "token", Hidden: false, Component: "view/token/token.vue", Sort: 2, Meta: model.Meta{Title: "token管理", Icon: "key"}},
 	{GVA_MODEL: global.GVA_MODEL{ID: 9, CreatedAt: time.Now(), UpdatedAt: time.Now()}, MenuLevel: 0, ParentId: "26", Path: "subdomain", Name: "subdomain", Hidden: false, Component: "view/subdomain/subdomain.vue", Sort: 2, Meta: model.Meta{Title: "子域名资产报告", Icon: "connection"}},
 	{GVA_MODEL: global.GVA_MODEL{ID: 10, CreatedAt: time.Now(), UpdatedAt: time.Now()}, MenuLevel: 0, ParentId: "24", Path: "filter", Name: "filter", Hidden: false, Component: "view/filter/filter.vue", Sort: 3, Meta: model.Meta{Title: "过滤规则", Icon: "filter"}},
+	{GVA_MODEL: global.GVA_MODEL{ID: 31, CreatedAt: time.Now(), UpdatedAt: time.Now()}, MenuLevel: 0, ParentId: "24", Path: "scanLog", Name: "scanLog", Hidden: false, Component: "view/scanLog/scanLog.vue", Sort: 4, Meta: model.Meta{Title: "扫描日志", Icon: "data-line"}},
 }
 
 func (m *menu) Init() error {
 	return global.GVA_DB.Transaction(func(tx *gorm.DB) error {
-		if tx.Where("id IN ?", []int{1, 29}).Find(&[]model.SysBaseMenu{}).RowsAffected == 2 {
+		if tx.Where("id IN ?", []int{1, 31}).Find(&[]model.SysBaseMenu{}).RowsAffected == 2 {
 			color.Danger.Println("\n[Mysql] --> sys_base_menus 表的初始数据已存在!")
 			return nil
 		}

--- a/sql.md
+++ b/sql.md
@@ -1,3 +1,75 @@
+## v2.1.14
+
+Add structured scanner lifecycle logs, scan progress monitoring, and the admin menu/API permissions used by the scan log page:
+
+```sql
+create table if not exists scan_log
+(
+    id               bigint unsigned auto_increment primary key,
+    created_at       datetime      null,
+    updated_at       datetime      null,
+    deleted_at       datetime      null,
+    cycle_id         varchar(36)   null,
+    provider         varchar(32)   null,
+    status           varchar(16)   null,
+    message          varchar(1000) null,
+    progress_current bigint        default 0 null,
+    progress_total   bigint        default 1 null,
+    started_at       datetime      null,
+    finished_at      datetime      null,
+    heartbeat_at     datetime      null,
+    duration_ms      bigint        default 0 null,
+    index idx_scan_log_deleted_at (deleted_at),
+    index idx_scan_log_cycle (cycle_id),
+    index idx_scan_log_provider (provider),
+    index idx_scan_log_status (status),
+    index idx_scan_log_heartbeat (heartbeat_at)
+);
+
+insert into sys_base_menus
+    (created_at, updated_at, deleted_at, menu_level, parent_id, path, name, hidden, component,
+     sort, keep_alive, default_menu, title, icon, close_tab)
+select current_timestamp, current_timestamp, null, 0, '24', 'scanLog', 'scanLog', 0,
+       'view/scanLog/scanLog.vue', 4, 0, 0, '扫描日志', 'data-line', 0
+where not exists (select 1 from sys_base_menus where name = 'scanLog');
+
+update sys_base_menus
+set icon = 'data-line'
+where name = 'scanLog' and coalesce(icon, '') <> 'data-line';
+
+insert into sys_authority_menus (sys_authority_authority_id, sys_base_menu_id)
+select '888', id from sys_base_menus where name = 'scanLog'
+and not exists (
+    select 1 from sys_authority_menus sam
+    where sam.sys_authority_authority_id = '888'
+      and sam.sys_base_menu_id = sys_base_menus.id
+);
+
+insert into sys_apis (created_at, updated_at, deleted_at, path, description, api_group, method)
+select current_timestamp, current_timestamp, null, '/scanLog/getScanLogList',
+       '获取扫描日志列表', 'scanLog', 'GET'
+where not exists (select 1 from sys_apis where path = '/scanLog/getScanLogList' and method = 'GET');
+
+insert into sys_apis (created_at, updated_at, deleted_at, path, description, api_group, method)
+select current_timestamp, current_timestamp, null, '/scanLog/getScanLogOverview',
+       '获取扫描状态概览', 'scanLog', 'GET'
+where not exists (select 1 from sys_apis where path = '/scanLog/getScanLogOverview' and method = 'GET');
+
+insert into casbin_rule (p_type, v0, v1, v2)
+select 'p', '888', '/scanLog/getScanLogList', 'GET'
+where not exists (
+    select 1 from casbin_rule
+    where p_type = 'p' and v0 = '888' and v1 = '/scanLog/getScanLogList' and v2 = 'GET'
+);
+
+insert into casbin_rule (p_type, v0, v1, v2)
+select 'p', '888', '/scanLog/getScanLogOverview', 'GET'
+where not exists (
+    select 1 from casbin_rule
+    where p_type = 'p' and v0 = '888' and v1 = '/scanLog/getScanLogOverview' and v2 = 'GET'
+);
+```
+
 ## v2.1.11
 
 Expand the repository field so full Postman request names and identifiers can be stored:
@@ -134,7 +206,4 @@ alter table token drop column description;
 insert into sys_apis (created_at, updated_at, deleted_at, path, description, api_group, method) VALUES 
 (current_timestamp, current_timestamp, null, '/email/botTest', '企业微信测试', 'email', 'GET');
 ```
-
-
-
 

--- a/web/src/api/scanLog.js
+++ b/web/src/api/scanLog.js
@@ -1,0 +1,16 @@
+import service from '@/utils/request'
+
+export const getScanLogList = (params) => {
+    return service({
+        url: '/scanLog/getScanLogList',
+        method: 'get',
+        params
+    })
+}
+
+export const getScanLogOverview = () => {
+    return service({
+        url: '/scanLog/getScanLogOverview',
+        method: 'get'
+    })
+}

--- a/web/src/utils/menuIcon.js
+++ b/web/src/utils/menuIcon.js
@@ -11,6 +11,7 @@ const iconMap = {
   user: 'User',
   'user-solid': 'UserFilled',
   'data-analysis': 'DataAnalysis',
+  'data-line': 'DataLine',
   's-operation': 'Operation',
   operation: 'Operation',
   monitor: 'Monitor',

--- a/web/src/view/scanLog/scanLog.vue
+++ b/web/src/view/scanLog/scanLog.vue
@@ -1,0 +1,424 @@
+<template>
+  <div class="scan-log-page">
+    <section class="scan-summary">
+      <div class="summary-copy">
+        <span class="summary-label">当前扫描周期</span>
+        <strong>{{ shortCycleId(overview.cycleId) }}</strong>
+        <span class="last-activity">最近活动 {{ formatDate(overview.lastActivityAt) || "--" }}</span>
+      </div>
+      <div class="summary-progress">
+        <div class="progress-meta">
+          <span>{{ overview.completed || 0 }}/{{ overview.total || providerOrder.length }} 已完成</span>
+          <span>{{ overview.progress || 0 }}%</span>
+        </div>
+        <el-progress
+          :percentage="overview.progress || 0"
+          :stroke-width="8"
+          :show-text="false"
+          :status="overview.abnormal > 0 ? 'exception' : undefined"
+        />
+      </div>
+      <div class="summary-metrics">
+        <div>
+          <span>运行中</span>
+          <strong>{{ overview.running || 0 }}</strong>
+        </div>
+        <div>
+          <span>异常</span>
+          <strong :class="{ danger: overview.abnormal > 0 }">{{ overview.abnormal || 0 }}</strong>
+        </div>
+      </div>
+    </section>
+
+    <section class="provider-grid" aria-label="扫描任务状态">
+      <article v-for="provider in providerStates" :key="provider.provider" class="provider-card">
+        <header>
+          <span class="provider-name">{{ providerLabel(provider.provider) }}</span>
+          <el-tag :type="statusTagType(provider)" effect="dark" size="small">
+            {{ statusLabel(provider) }}
+          </el-tag>
+        </header>
+        <p>{{ provider.message || "等待扫描数据" }}</p>
+        <footer>
+          <span>{{ providerTime(provider) }}</span>
+          <span v-if="provider.durationMs">{{ formatDuration(provider.durationMs) }}</span>
+        </footer>
+      </article>
+    </section>
+
+    <div class="search-term scan-toolbar">
+      <el-form :inline="true" :model="searchInfo">
+        <el-form-item label="平台">
+          <el-select v-model="searchInfo.provider" clearable placeholder="全部平台" style="width: 150px">
+            <el-option
+              v-for="provider in providerOrder"
+              :key="provider"
+              :label="providerLabel(provider)"
+              :value="provider"
+            />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="状态">
+          <el-select v-model="searchInfo.status" clearable placeholder="全部状态" style="width: 150px">
+            <el-option v-for="status in statusOptions" :key="status.value" :label="status.label" :value="status.value" />
+          </el-select>
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" :icon="Search" @click="applyFilters">查询</el-button>
+          <el-tooltip content="重置筛选" placement="top">
+            <el-button :icon="RefreshLeft" circle aria-label="重置筛选" @click="resetFilters" />
+          </el-tooltip>
+        </el-form-item>
+      </el-form>
+      <div class="toolbar-actions">
+        <span>自动刷新</span>
+        <el-switch v-model="autoRefresh" @change="syncTimer" />
+        <el-tooltip content="立即刷新" placement="top">
+          <el-button :icon="Refresh" circle :loading="loading" aria-label="立即刷新" @click="refreshAll" />
+        </el-tooltip>
+      </div>
+    </div>
+
+    <el-table v-loading="loading" :data="tableData" border stripe style="width: 100%">
+      <el-table-column label="开始时间" min-width="170">
+        <template #default="scope">{{ formatDate(scope.row.startedAt || scope.row.CreatedAt) }}</template>
+      </el-table-column>
+      <el-table-column label="平台" min-width="110">
+        <template #default="scope">{{ providerLabel(scope.row.provider) }}</template>
+      </el-table-column>
+      <el-table-column label="状态" min-width="110">
+        <template #default="scope">
+          <el-tag :type="statusTagType(scope.row)" effect="dark" size="small">
+            {{ statusLabel(scope.row) }}
+          </el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column label="耗时" min-width="100">
+        <template #default="scope">{{ formatDuration(scope.row.durationMs) }}</template>
+      </el-table-column>
+      <el-table-column label="周期" min-width="130">
+        <template #default="scope">
+          <span class="cycle-id" :title="scope.row.cycleId">{{ shortCycleId(scope.row.cycleId) }}</span>
+        </template>
+      </el-table-column>
+      <el-table-column label="信息" prop="message" min-width="320" show-overflow-tooltip />
+      <el-table-column label="最近心跳" min-width="170">
+        <template #default="scope">{{ formatDate(scope.row.heartbeatAt) || "--" }}</template>
+      </el-table-column>
+    </el-table>
+
+    <el-pagination
+      :current-page="page"
+      :page-size="pageSize"
+      :page-sizes="[10, 30, 50, 100]"
+      :total="total"
+      layout="total, sizes, prev, pager, next, jumper"
+      @current-change="handleCurrentChange"
+      @size-change="handleSizeChange"
+    />
+  </div>
+</template>
+
+<script>
+import { markRaw } from "vue";
+import { Refresh, RefreshLeft, Search } from "@element-plus/icons-vue";
+import { getScanLogList, getScanLogOverview } from "@/api/scanLog";
+import { formatDate } from "@/utils/date";
+
+const EMPTY_OVERVIEW = {
+  cycleId: "",
+  logs: [],
+  total: 0,
+  completed: 0,
+  running: 0,
+  abnormal: 0,
+  progress: 0,
+  lastActivityAt: null,
+};
+
+export default {
+  name: "ScanLog",
+  data() {
+    return {
+      Refresh: markRaw(Refresh),
+      RefreshLeft: markRaw(RefreshLeft),
+      Search: markRaw(Search),
+      providerOrder: ["gitlab", "searchcode", "github", "gobuster", "postman"],
+      statusOptions: [
+        { value: "pending", label: "排队中" },
+        { value: "running", label: "运行中" },
+        { value: "success", label: "成功" },
+        { value: "skipped", label: "已跳过" },
+        { value: "failed", label: "失败" },
+        { value: "timeout", label: "超时" },
+        { value: "interrupted", label: "已中断" },
+      ],
+      overview: { ...EMPTY_OVERVIEW },
+      searchInfo: { provider: "", status: "" },
+      tableData: [],
+      page: 1,
+      pageSize: 30,
+      total: 0,
+      loading: false,
+      autoRefresh: true,
+      timer: null,
+    };
+  },
+  computed: {
+    providerStates() {
+      const logs = new Map((this.overview.logs || []).map((item) => [item.provider, item]));
+      return this.providerOrder.map((provider) => logs.get(provider) || {
+        provider,
+        status: "pending",
+        message: "等待扫描数据",
+      });
+    },
+  },
+  methods: {
+    formatDate,
+    providerLabel(provider) {
+      const labels = {
+        gitlab: "GitLab",
+        searchcode: "Searchcode",
+        github: "GitHub",
+        gobuster: "Domain",
+        postman: "Postman",
+      };
+      return labels[provider] || provider || "--";
+    },
+    statusLabel(item) {
+      if (item.stale) return "心跳异常";
+      const option = this.statusOptions.find((status) => status.value === item.status);
+      return option ? option.label : item.status || "未知";
+    },
+    statusTagType(item) {
+      if (item.stale || ["failed", "timeout", "interrupted"].includes(item.status)) return "danger";
+      if (item.status === "success") return "success";
+      if (item.status === "running") return "primary";
+      if (item.status === "skipped") return "info";
+      return "warning";
+    },
+    shortCycleId(cycleId) {
+      return cycleId ? cycleId.slice(0, 8) : "--";
+    },
+    formatDuration(durationMs) {
+      if (!durationMs) return "--";
+      if (durationMs < 1000) return `${durationMs} ms`;
+      if (durationMs < 60000) return `${(durationMs / 1000).toFixed(1)} s`;
+      const minutes = Math.floor(durationMs / 60000);
+      const seconds = Math.floor((durationMs % 60000) / 1000);
+      return `${minutes}m ${seconds}s`;
+    },
+    providerTime(provider) {
+      if (provider.status === "running") return `心跳 ${formatDate(provider.heartbeatAt) || "--"}`;
+      return formatDate(provider.finishedAt || provider.CreatedAt) || "--";
+    },
+    async refreshAll() {
+      if (this.loading) return;
+      this.loading = true;
+      try {
+        const [overviewRes, listRes] = await Promise.all([
+          getScanLogOverview(),
+          getScanLogList({
+            page: this.page,
+            pageSize: this.pageSize,
+            ...this.searchInfo,
+          }),
+        ]);
+        if (overviewRes.code === 0) this.overview = overviewRes.data || { ...EMPTY_OVERVIEW };
+        if (listRes.code === 0) {
+          this.tableData = listRes.data.list || [];
+          this.total = listRes.data.total || 0;
+          this.page = listRes.data.page || this.page;
+          this.pageSize = listRes.data.pageSize || this.pageSize;
+        }
+      } finally {
+        this.loading = false;
+      }
+    },
+    applyFilters() {
+      this.page = 1;
+      this.refreshAll();
+    },
+    resetFilters() {
+      this.searchInfo = { provider: "", status: "" };
+      this.page = 1;
+      this.refreshAll();
+    },
+    handleCurrentChange(page) {
+      this.page = page;
+      this.refreshAll();
+    },
+    handleSizeChange(pageSize) {
+      this.pageSize = pageSize;
+      this.page = 1;
+      this.refreshAll();
+    },
+    syncTimer() {
+      if (this.timer) clearInterval(this.timer);
+      this.timer = this.autoRefresh ? setInterval(this.refreshAll, 5000) : null;
+    },
+  },
+  created() {
+    this.refreshAll();
+    this.syncTimer();
+  },
+  beforeUnmount() {
+    if (this.timer) clearInterval(this.timer);
+  },
+};
+</script>
+
+<style scoped>
+.scan-log-page {
+  min-width: 0;
+}
+
+.scan-summary {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.8fr) minmax(280px, 1.4fr) auto;
+  gap: 28px;
+  align-items: center;
+  padding: 18px 2px 20px;
+  border-bottom: 1px solid var(--el-border-color);
+}
+
+.summary-copy,
+.summary-progress {
+  min-width: 0;
+}
+
+.summary-copy {
+  display: grid;
+  gap: 4px;
+}
+
+.summary-label,
+.last-activity,
+.progress-meta,
+.summary-metrics span,
+.provider-card footer {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+}
+
+.summary-copy strong {
+  font-size: 22px;
+  letter-spacing: 0;
+}
+
+.progress-meta {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.summary-metrics {
+  display: flex;
+  gap: 28px;
+}
+
+.summary-metrics div {
+  display: grid;
+  gap: 2px;
+  min-width: 58px;
+}
+
+.summary-metrics strong {
+  font-size: 24px;
+  font-variant-numeric: tabular-nums;
+}
+
+.summary-metrics strong.danger {
+  color: var(--el-color-danger);
+}
+
+.provider-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(150px, 1fr));
+  gap: 12px;
+  margin: 18px 0;
+}
+
+.provider-card {
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid var(--el-border-color);
+  border-radius: 6px;
+  background: var(--el-bg-color-overlay);
+}
+
+.provider-card header,
+.provider-card footer,
+.scan-toolbar,
+.toolbar-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.provider-name {
+  overflow: hidden;
+  font-weight: 600;
+  text-overflow: ellipsis;
+}
+
+.provider-card p {
+  height: 40px;
+  margin: 12px 0;
+  overflow: hidden;
+  color: var(--el-text-color-regular);
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.provider-card footer span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.scan-toolbar {
+  flex-wrap: wrap;
+}
+
+.scan-toolbar :deep(.el-form-item) {
+  margin-bottom: 0;
+}
+
+.toolbar-actions {
+  color: var(--el-text-color-secondary);
+  font-size: 13px;
+}
+
+.cycle-id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+@media (max-width: 1100px) {
+  .provider-grid {
+    grid-template-columns: repeat(3, minmax(160px, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .scan-summary {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .provider-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .summary-metrics {
+    justify-content: flex-start;
+  }
+
+  .scan-toolbar,
+  .toolbar-actions {
+    align-items: flex-start;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- Add a `scan_log` table plus API/UI to track each provider's scan status (pending/running/success/skipped/failed/timeout/interrupted), progress, and heartbeat, so a stuck or crashed provider is visible instead of silently timing out.
- Refactor `ScanTask` into discrete, injectable scan cycles (`runScanCycle`/`runProvider`) with a heartbeat ticker alongside the existing watchdog, and recover from provider panics instead of crashing the loop.
- Mark any logs left `running`/`pending` from a prior process as `interrupted` on startup.
- Add a "扫描日志" (Scan Log) menu/page with a status overview endpoint.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (server)
- [x] `npx vite build` (web)
- [ ] Manual smoke test of the new Scan Log page against a running server

🤖 Generated with [Claude Code](https://claude.com/claude-code)