### PR TITLE
docs(sql): warn to use utf8mb4 client charset when applying upgrade SQL

### DIFF
--- a/sql.md
+++ b/sql.md
@@ -1,3 +1,16 @@
+# Upgrade SQL
+
+> **Character set notice:** the statements below contain Chinese text. When applying them
+> with the `mysql` command-line client (especially inside the MySQL Docker container, whose
+> client defaults to latin1), always pass `--default-character-set=utf8mb4`, e.g.
+>
+> ```bash
+> docker exec -i gshark-mysql mysql --default-character-set=utf8mb4 -uroot -p gshark < upgrade.sql
+> ```
+>
+> Without it the UTF-8 text is double-encoded and menu titles/API descriptions show up as
+> mojibake (e.g. `æ‰«æ...`) in the admin UI.
+
 ## v2.1.14
 
 Add structured scanner lifecycle logs, scan progress monitoring, and the admin menu/API permissions used by the scan log page:


### PR DESCRIPTION
## Summary
- Add a notice at the top of `sql.md`: when applying upgrade SQL with the `mysql` CLI (notably inside the MySQL Docker container, which defaults to latin1), pass `--default-character-set=utf8mb4`.
- Without the flag, the Chinese seed data (menu titles, API descriptions) gets double-encoded into mojibake in the admin UI — this bit us during the v2.1.14 deployment.

Docs-only change; no code or release impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)