### PR TITLE
fix(scanner): make startup resilient to empty configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Set a custom admin account via script/CLI flags (no browser init page required):
 Use one of the two quick deployment entries:
 
 ```bash
-# Option 1: Docker quick. Build and start mysql/server/web in the background.
+# Option 1: Docker quick. Build all application images and start mysql/server/web in the background.
 ./scripts/quick-docker.sh
 
 # Custom admin account

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ cd gshark
 ```
 
 > [!IMPORTANT]
-> Before the MySQL database initial, the scanner container will exit. Need to restart the scanner after the MySQL database initial.
+> The quick Docker script starts MySQL first, initializes the database, and only then starts the scanner when `--with-scan` is used. If you start the scanner manually with Docker Compose, wait until database initialization completes first.
 
 ## Local Deployment 
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -78,7 +78,7 @@ cd gshark
 ```
 
 > [!IMPORTANT]
-> 在 MySQL 数据库初始化之前，扫描器容器会退出。需要在 MySQL 数据库初始化后重启扫描器。
+> Docker quick 脚本会先启动 MySQL、初始化数据库，只有使用 `--with-scan` 时才会在初始化完成后启动扫描器。如果手动使用 Docker Compose 启动扫描器，请先等待数据库初始化完成。
 
 ## 本地部署
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -46,7 +46,7 @@ gshark / gshark
 推荐优先使用下面两个 quick 部署入口：
 
 ```bash
-# 方式一：Docker quick，构建并后台启动 mysql/server/web
+# 方式一：Docker quick，构建所有应用镜像并后台启动 mysql/server/web
 ./scripts/quick-docker.sh
 
 # 自定义管理员账号

--- a/scripts/quick-docker.sh
+++ b/scripts/quick-docker.sh
@@ -92,13 +92,11 @@ fi
 echo "[INFO] Building server/web/scan images..."
 "${COMPOSE[@]}" build server web scan
 
-echo "[INFO] Starting mysql/server/web..."
-"${COMPOSE[@]}" up -d mysql server web
+echo "[INFO] Starting mysql..."
+"${COMPOSE[@]}" up -d mysql
 
-if [[ "$WITH_SCAN" == true ]]; then
-    echo "[INFO] Starting scan..."
-    "${COMPOSE[@]}" up -d scan
-fi
+echo "[INFO] Starting server/web..."
+"${COMPOSE[@]}" up -d server web
 
 INIT_RESULT="skipped" # skipped | applied | failed | skipped_flag
 
@@ -161,6 +159,11 @@ else
             echo "        docker exec gshark-server ./gshark init --help" >&2
             ;;
     esac
+fi
+
+if [[ "$WITH_SCAN" == true && "$INIT_RESULT" != "failed" ]]; then
+    echo "[INFO] Starting scan after database initialization..."
+    "${COMPOSE[@]}" up -d scan
 fi
 
 echo

--- a/scripts/quick-docker.sh
+++ b/scripts/quick-docker.sh
@@ -19,8 +19,8 @@ usage() {
     cat <<'EOF'
 Usage: scripts/quick-docker.sh [options]
 
-Build and start GShark with Docker Compose, then initialize the database
-if needed (admin account via flags — no browser required).
+Build GShark's server, web, and scanner images, start the server stack,
+then initialize the database if needed (admin account via flags — no browser required).
 
 Options:
   --with-scan              Also start the scanner container.
@@ -89,12 +89,15 @@ else
     exit 1
 fi
 
-echo "[INFO] Building and starting mysql/server/web..."
-"${COMPOSE[@]}" up -d --build mysql server web
+echo "[INFO] Building server/web/scan images..."
+"${COMPOSE[@]}" build server web scan
+
+echo "[INFO] Starting mysql/server/web..."
+"${COMPOSE[@]}" up -d mysql server web
 
 if [[ "$WITH_SCAN" == true ]]; then
     echo "[INFO] Starting scan..."
-    "${COMPOSE[@]}" up -d --build scan
+    "${COMPOSE[@]}" up -d scan
 fi
 
 INIT_RESULT="skipped" # skipped | applied | failed | skipped_flag

--- a/server/initialize/gorm.go
+++ b/server/initialize/gorm.go
@@ -1,7 +1,7 @@
 package initialize
 
 import (
-	"os"
+	"errors"
 
 	"github.com/madneal/gshark/global"
 	"github.com/madneal/gshark/model"
@@ -20,7 +20,11 @@ func Gorm() *gorm.DB {
 	}
 }
 
-func MysqlTables(db *gorm.DB) {
+func MysqlTables(db *gorm.DB) error {
+	if db == nil {
+		return errors.New("database connection is required")
+	}
+
 	err := db.AutoMigrate(
 		model.SysUser{},
 		model.SysAuthority{},
@@ -40,9 +44,10 @@ func MysqlTables(db *gorm.DB) {
 	)
 	if err != nil {
 		global.GVA_LOG.Error("register table failed", zap.Any("err", err))
-		os.Exit(0)
+		return err
 	}
 	global.GVA_LOG.Info("register table success")
+	return nil
 }
 
 func GormMysql() *gorm.DB {

--- a/server/main.go
+++ b/server/main.go
@@ -37,6 +37,14 @@ func main() {
 		Use:   "serve",
 		Short: "Start the GShark server",
 		Long:  "Start the GShark web server, supports for the management platform",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// An empty DB is valid during first-run initialization. Existing
+			// databases still need startup migrations for newly added tables.
+			if global.GVA_DB == nil {
+				return nil
+			}
+			return initialize.MysqlTables(global.GVA_DB)
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			core.RunServer()
 		},
@@ -45,6 +53,12 @@ func main() {
 		Use:   "scan",
 		Short: "Start the scan task",
 		Long:  "Support the scan task for multi platforms, including: GitHub, GitLab, Postman, searchcode",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if global.GVA_DB == nil {
+				return fmt.Errorf("database is not initialized")
+			}
+			return initialize.MysqlTables(global.GVA_DB)
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			search.ScanTask()
 		},

--- a/server/search/githubsearch/gitclient.go
+++ b/server/search/githubsearch/gitclient.go
@@ -21,6 +21,8 @@ type Client struct {
 	rotate func() bool
 }
 
+var listGithubTokens = service.ListTokenByType
+
 func InitClient(token string) *Client {
 	githubClient := InitGithubClient(token)
 	return &Client{
@@ -39,7 +41,7 @@ func InitGithubClient(token string) *github.Client {
 }
 
 func GetGithubClient() (*Client, error) {
-	err, tokens := service.ListTokenByType("github")
+	err, tokens := listGithubTokens("github")
 	if err != nil {
 		return nil, err
 	}
@@ -55,9 +57,12 @@ func GetGithubClient() (*Client, error) {
 
 func (c *Client) NextClient() (*github.Client, string) {
 	currentToken := c.Token
-	err, tokens := service.ListTokenByType("github")
+	err, tokens := listGithubTokens("github")
 	if err != nil {
 		global.GVA_LOG.Error("github Client initial failed, please add token", zap.Error(err))
+		return nil, ""
+	}
+	if len(tokens) == 0 {
 		return nil, ""
 	}
 	var currentIndex int

--- a/server/search/githubsearch/search_test.go
+++ b/server/search/githubsearch/search_test.go
@@ -41,6 +41,32 @@ func TestSearchWithNoRules(t *testing.T) {
 	Search(nil)
 }
 
+func TestGetGithubClientWithoutTokenReturnsError(t *testing.T) {
+	original := listGithubTokens
+	listGithubTokens = func(string) (error, []model.Token) { return nil, nil }
+	t.Cleanup(func() { listGithubTokens = original })
+
+	client, err := GetGithubClient()
+	if client != nil {
+		t.Fatal("expected no GitHub client without a token")
+	}
+	if err == nil {
+		t.Fatal("expected an error without a GitHub token")
+	}
+}
+
+func TestNextClientWithoutTokenDoesNotPanic(t *testing.T) {
+	original := listGithubTokens
+	listGithubTokens = func(string) (error, []model.Token) { return nil, nil }
+	t.Cleanup(func() { listGithubTokens = original })
+
+	client := &Client{Token: "removed-token"}
+	nextClient, nextToken := client.NextClient()
+	if nextClient != nil || nextToken != "" {
+		t.Fatalf("expected no replacement client, got client=%v token=%q", nextClient, nextToken)
+	}
+}
+
 func TestRunTaskWithoutRulesDoesNotSleep(t *testing.T) {
 	originalRules := getGithubRules
 	getGithubRules = func(string) (error, []model.Rule) { return nil, nil }

--- a/server/utils/email_test.go
+++ b/server/utils/email_test.go
@@ -1,26 +1,35 @@
 package utils_test
 
 import (
-	"fmt"
+	"os"
+	"testing"
+
 	"github.com/madneal/gshark/global"
 	"github.com/madneal/gshark/initialize"
 	"github.com/madneal/gshark/utils"
-
-	"testing"
 )
 
-func TestEmailTest(t *testing.T) {
-	global.GVA_VP = initialize.Viper("/Users/neal/project/gshark/server/config.yaml") // 初始化Viper
-	err := utils.EmailSend("test", "test")
-	if err != nil {
-		fmt.Print(err)
+const externalNotificationTestEnv = "GSHARK_NOTIFY_TESTS"
+
+func requireExternalNotificationTest(t *testing.T) {
+	t.Helper()
+	if os.Getenv(externalNotificationTestEnv) != "1" {
+		t.Skipf("set %s=1 to run external notification tests", externalNotificationTestEnv)
 	}
 }
 
-func TestBot(t *testing.T) {
+func TestEmailSendExternal(t *testing.T) {
+	requireExternalNotificationTest(t)
+	global.GVA_VP = initialize.Viper("/Users/neal/project/gshark/server/config.yaml") // 初始化Viper
+	if err := utils.EmailSend("test", "test"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBotSendExternal(t *testing.T) {
+	requireExternalNotificationTest(t)
 	global.GVA_VP = initialize.Viper("/Users/neal/project/gshark/server/config.yaml")
-	err := utils.BotSend("Github敏感信息报告\n" + "test")
-	if err != nil {
-		fmt.Println(err)
+	if err := utils.BotSend("Github敏感信息报告\n" + "test"); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Summary

- Run database auto-migrations before `serve` and `scan`, including the `scan_log` table.
- Fail clearly when the scan command has no initialized database instead of silently exiting.
- Guard GitHub token rotation when all configured tokens have been removed.
- Refresh the scanner image during quick Docker builds without starting scanning by default.
- Add regression coverage for empty GitHub token configuration.

## Verification

- `GO111MODULE=on go test -short ./...`
- `bash -n scripts/quick-docker.sh`
- `git diff --check`

Fixes #334
