### PR TITLE
fix(github): respect environment proxy in client transport

### DIFF
--- a/server/search/githubsearch/gitclient.go
+++ b/server/search/githubsearch/gitclient.go
@@ -30,12 +30,15 @@ func InitClient(token string) *Client {
 }
 
 func InitGithubClient(token string) *github.Client {
-	httpTransport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	httpClient := &http.Client{Transport: httpTransport}
+	httpClient := &http.Client{Transport: newGithubHTTPTransport()}
 	gitClient := github.NewClient(httpClient).WithAuthToken(token)
 	return gitClient
+}
+
+func newGithubHTTPTransport() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	return transport
 }
 
 func GetGithubClient() (*Client, error) {

--- a/server/search/githubsearch/search_test.go
+++ b/server/search/githubsearch/search_test.go
@@ -41,6 +41,16 @@ func TestSearchWithNoRules(t *testing.T) {
 	Search(nil)
 }
 
+func TestGithubHTTPTransportPreservesDefaultProxy(t *testing.T) {
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok || defaultTransport.Proxy == nil {
+		t.Fatal("expected the default HTTP transport to provide an environment proxy")
+	}
+	if newGithubHTTPTransport().Proxy == nil {
+		t.Fatal("expected GitHub transport to preserve the default environment proxy")
+	}
+}
+
 func TestRunTaskWithoutRulesDoesNotSleep(t *testing.T) {
 	originalRules := getGithubRules
 	getGithubRules = func(string) (error, []model.Rule) { return nil, nil }


### PR DESCRIPTION
## Problem

The GitHub search client creates a custom `http.Transport` with a TLS configuration, but leaves `Transport.Proxy` unset. A custom transport does not inherit Go's default `ProxyFromEnvironment`, so `HTTP_PROXY` and `HTTPS_PROXY` configured for the scanner are bypassed and GitHub requests connect directly.

## Solution

- Clone `http.DefaultTransport` so the standard proxy behavior and transport defaults are preserved.
- Keep the existing `InsecureSkipVerify` setting because the deployment requires it.
- Add a regression test that verifies the GitHub transport preserves the default proxy function.

SearchCode's separate upstream `404` response is not changed by this PR.

## Verification

- `GO111MODULE=on go test ./search/githubsearch -run 'TestGithubHTTPTransportPreservesDefaultProxy|TestSearchCodeByOpt' -count=1`
- `GO111MODULE=on go test -short ./source ./service ./router`
- `git diff --check`
