### PR TITLE
feat(search): scan GitHub issues, PRs, and gists

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,14 +262,22 @@ To execute the scan task for GitHub, you need to add a GitHub token for crawl in
 
 ### Rule Configuration
 
-For the Github or Gitlab rule, the rule will be matched by the syntax in the corresponding platforms. Directly, you config what you search at GitHub. You can download the rule import template CSV file, then batch import rules.
+For the Github or Gitlab rule, the rule will be matched by the syntax in the corresponding platforms. Directly, you config what you search at GitHub. GitHub rules reuse the same token across three surfaces:
+
+* `github` — repository code search (`in:file`)
+* `github_issue` — issues and pull requests (`in:title,body,comments`; you can add `is:issue` or `is:pr`)
+* `gist` — public Gist search; the scanner then loads matching gist files through the official Gist API
+
+One rule can enable several types at once, for example `github,github_issue,gist`.
+
+You can download the rule import template CSV file, then batch import rules.
 
 <img width="572" alt="image" src="https://user-images.githubusercontent.com/12164075/212504597-3e1ad5bd-bacf-433e-83e8-08de7eee6509.png">
 
 
 ### Filter Configuration
 
-Filters currently apply only to GitHub search. The supported classes are `extension` and `keyword`, and both can be configured as a blacklist or whitelist.
+Filters currently apply to GitHub surfaces. `keyword` filters apply to `github`, `github_issue`, and `gist`. `extension` filters apply to `github` code search and `gist` search. Both classes can be configured as a blacklist or whitelist.
 
 For more information, you can refer to this [video](https://www.bilibili.com/video/BV1aG4y1c72N/?vd_source=ef4657ebf0549af8755f75118b6e81bb).
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -261,13 +261,21 @@ npm run serve
 
 ### 规则配置
 
-对于 Github 或 Gitlab 规则，规则将按照相应平台的语法进行匹配。您可以直接配置在 GitHub 中搜索的内容。您可以下载规则导入模板 CSV 文件，然后批量导入规则。
+对于 Github 或 Gitlab 规则，规则将按照相应平台的语法进行匹配。您可以直接配置在 GitHub 中搜索的内容。同一套 GitHub token 会覆盖三个面：
+
+* `github`：仓库代码搜索（`in:file`）
+* `github_issue`：Issue 和 PR（默认 `in:title,body,comments`，也可自行加 `is:issue` / `is:pr`）
+* `gist`：公开 Gist 搜索，命中后再通过官方 Gist API 拉取文件内容
+
+同一条规则可以勾选多种类型，例如 `github,github_issue,gist`。
+
+您可以下载规则导入模板 CSV 文件，然后批量导入规则。
 
 <img width="572" alt="image" src="https://user-images.githubusercontent.com/12164075/212504597-3e1ad5bd-bacf-433e-83e8-08de7eee6509.png">
 
 ### 过滤器配置
 
-过滤器目前仅针对 GitHub 搜索，支持 `extension` 和 `keyword` 两类，两者都可以配置为黑名单或白名单。
+过滤器目前针对 GitHub 相关扫描。`keyword` 适用于 `github`、`github_issue` 和 `gist`；`extension` 适用于 `github` 代码搜索和 `gist`。两类都可以配置为黑名单或白名单。
 
 更多信息，您可以参考这个[视频](https://www.bilibili.com/video/BV1aG4y1c72N/?vd_source=ef4657ebf0549af8755f75118b6e81bb)。
 

--- a/server/search/githubsearch/gists.go
+++ b/server/search/githubsearch/gists.go
@@ -23,7 +23,7 @@ const (
 	maxGistSearchPages     = 5
 	maxGistSearchPageBytes = 2 << 20
 	gistSearchTimeout      = 30 * time.Second
-	maxPublicGistFallback  = 50
+	gistSearchUserAgent    = "GShark (+https://github.com/madneal/gshark)"
 )
 
 var gistPathRe = regexp.MustCompile(`href="/(?P<owner>[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)/(?P<id>[0-9a-f]{20,32})(?:["/#?])`)
@@ -74,20 +74,16 @@ func (c *Client) SearchGistHits(query string) ([]gistHit, error) {
 	seen := make(map[string]struct{})
 	hits := make([]gistHit, 0)
 	for page := 1; page <= maxGistSearchPages; page++ {
-		body, err := fetchGistSearchPage(c.Token, query, page)
+		body, err := fetchGistSearchPage(query, page)
 		if err != nil {
 			if page == 1 {
-				global.GVA_LOG.Warn("gist HTML search failed, falling back to public gist stream", zap.Error(err))
-				return c.listRecentPublicGists()
+				return nil, err
 			}
+			global.GVA_LOG.Warn("gist HTML search stopped after a later page error", zap.Int("page", page), zap.Error(err))
 			break
 		}
 		pageHits := parseGistSearchHTML(body)
 		if len(pageHits) == 0 {
-			if page == 1 {
-				global.GVA_LOG.Warn("gist HTML search returned no parseable hits, falling back to public gist stream")
-				return c.listRecentPublicGists()
-			}
 			break
 		}
 		added := 0
@@ -104,45 +100,6 @@ func (c *Client) SearchGistHits(query string) ([]gistHit, error) {
 		}
 	}
 	return hits, nil
-}
-
-func (c *Client) listRecentPublicGists() ([]gistHit, error) {
-	ctx := context.Background()
-	opt := &github.GistListOptions{ListOptions: github.ListOptions{PerPage: 100}}
-	hits := make([]gistHit, 0, maxPublicGistFallback)
-	for {
-		gists, res, err := c.getPublicGists(ctx, opt)
-		if err != nil {
-			return hits, err
-		}
-		for _, gist := range gists {
-			if gist == nil || gist.GetID() == "" {
-				continue
-			}
-			hits = append(hits, gistHit{Owner: gistOwnerLogin(gist), ID: gist.GetID()})
-			if len(hits) >= maxPublicGistFallback {
-				return hits, nil
-			}
-		}
-		if res == nil || res.NextPage <= 0 {
-			return hits, nil
-		}
-		opt.Page = res.NextPage
-	}
-}
-
-func (c *Client) getPublicGists(ctx context.Context, opt *github.GistListOptions) ([]*github.Gist, *github.Response, error) {
-	for attempt := 1; attempt <= maxSearchAttempts; attempt++ {
-		gists, res, err := c.Client.Gists.ListAll(ctx, opt)
-		if err == nil {
-			c.noteSearchResponse("gists/public", res)
-			return gists, res, nil
-		}
-		if !c.recoverSearchError("gists/public", err, attempt) {
-			return nil, res, err
-		}
-	}
-	return nil, nil, errors.New("exhausted retry attempts for public gist list")
 }
 
 func (c *Client) LoadGistResults(hits []gistHit, keyword string) ([]model.SearchResult, error) {
@@ -167,11 +124,23 @@ func (c *Client) getGist(ctx context.Context, id string) (*github.Gist, error) {
 			c.noteSearchResponse("gists/"+id, res)
 			return gist, nil
 		}
+		if isNonRetryableAPIError(err) {
+			return nil, err
+		}
 		if !c.recoverSearchError("gists/"+id, err, attempt) {
 			return nil, err
 		}
 	}
 	return nil, fmt.Errorf("exhausted retry attempts for gist %s", id)
+}
+
+func isNonRetryableAPIError(err error) bool {
+	var errResp *github.ErrorResponse
+	if !errors.As(err, &errResp) || errResp.Response == nil {
+		return false
+	}
+	code := errResp.Response.StatusCode
+	return code != http.StatusTooManyRequests && code >= 400 && code < 500
 }
 
 func convertGistToSearchResults(gist *github.Gist, hit gistHit, keyword string) []model.SearchResult {
@@ -195,6 +164,9 @@ func convertGistToSearchResults(gist *github.Gist, hit gistHit, keyword string) 
 		name := file.GetFilename()
 		if name == "" {
 			name = string(filename)
+		}
+		if !gistAllowsExtension(name) {
+			continue
 		}
 		fragment := gistFileFragment(file.GetContent(), keyword)
 		if keyword != "" && !gistMatchesKeyword(name, gist.GetDescription(), file.GetContent(), keyword) {
@@ -222,7 +194,7 @@ func convertGistToSearchResults(gist *github.Gist, hit gistHit, keyword string) 
 		}
 		results = append(results, item)
 	}
-	if len(results) == 0 && gist.GetDescription() != "" && gistMatchesKeyword("", gist.GetDescription(), "", keyword) {
+	if len(results) == 0 && gistAllowsExtension("") && gist.GetDescription() != "" && gistMatchesKeyword("", gist.GetDescription(), "", keyword) {
 		results = append(results, model.SearchResult{
 			Repo:    repo,
 			RepoUrl: htmlURL,
@@ -236,20 +208,10 @@ func convertGistToSearchResults(gist *github.Gist, hit gistHit, keyword string) 
 	return results
 }
 
+var gistQueryQualifiers = []string{"extension:", "language:", "filename:", "user:", "in:"}
+
 func gistMatchesKeyword(filename, description, content, keyword string) bool {
-	needle := strings.ToLower(strings.TrimSpace(keyword))
-	if needle == "" {
-		return true
-	}
-	// Drop filter-style tokens so "company -extension:md" still matches "company".
-	fields := strings.Fields(needle)
-	needles := make([]string, 0, len(fields))
-	for _, field := range fields {
-		if strings.HasPrefix(field, "-") || strings.HasPrefix(field, "+") || strings.Contains(field, ":") {
-			continue
-		}
-		needles = append(needles, field)
-	}
+	needles := gistNeedles(keyword)
 	if len(needles) == 0 {
 		return true
 	}
@@ -260,6 +222,75 @@ func gistMatchesKeyword(filename, description, content, keyword string) bool {
 		}
 	}
 	return true
+}
+
+func gistNeedles(keyword string) []string {
+	needles := make([]string, 0)
+	for _, field := range strings.Fields(strings.ToLower(strings.TrimSpace(keyword))) {
+		denied := strings.HasPrefix(field, "-")
+		field = strings.TrimPrefix(strings.TrimPrefix(field, "+"), "-")
+		if field == "" || isGistQueryQualifier(field) {
+			continue
+		}
+		if denied {
+			continue
+		}
+		needles = append(needles, field)
+	}
+	return needles
+}
+
+func isGistQueryQualifier(field string) bool {
+	for _, prefix := range gistQueryQualifiers {
+		if strings.HasPrefix(field, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func gistAllowsExtension(filename string) bool {
+	err, filters := getFiltersByClass("extension")
+	if err != nil || len(filters) == 0 {
+		return true
+	}
+	ext := fileExtension(filename)
+	hasAllow := false
+	allowed := false
+	for _, filter := range filters {
+		for _, raw := range strings.Split(filter.Content, ",") {
+			want := strings.TrimPrefix(strings.TrimSpace(strings.ToLower(raw)), ".")
+			if want == "" {
+				continue
+			}
+			if filter.FilterType == "blacklist" {
+				if ext == want {
+					return false
+				}
+				continue
+			}
+			hasAllow = true
+			if ext == want {
+				allowed = true
+			}
+		}
+	}
+	if hasAllow {
+		return allowed
+	}
+	return true
+}
+
+func fileExtension(filename string) string {
+	base := filename
+	if i := strings.LastIndex(filename, "/"); i >= 0 {
+		base = filename[i+1:]
+	}
+	dot := strings.LastIndex(base, ".")
+	if dot < 0 || dot == len(base)-1 {
+		return ""
+	}
+	return strings.ToLower(base[dot+1:])
 }
 
 func gistFileFragment(content, keyword string) string {
@@ -324,7 +355,7 @@ func parseGistSearchHTML(body string) []gistHit {
 	return hits
 }
 
-func defaultFetchGistSearchPage(token, query string, page int) (string, error) {
+func defaultFetchGistSearchPage(query string, page int) (string, error) {
 	endpoint := fmt.Sprintf("https://gist.github.com/search?q=%s&p=%d", url.QueryEscape(strings.TrimSpace(query)), page)
 	var lastErr error
 	for attempt := 1; attempt <= maxSearchAttempts; attempt++ {
@@ -332,11 +363,8 @@ func defaultFetchGistSearchPage(token, query string, page int) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		req.Header.Set("User-Agent", "gshark")
+		req.Header.Set("User-Agent", gistSearchUserAgent)
 		req.Header.Set("Accept", "text/html")
-		if token != "" {
-			req.Header.Set("Authorization", "Bearer "+token)
-		}
 		resp, err := gistSearchClient.Do(req)
 		if err != nil {
 			lastErr = err
@@ -352,7 +380,7 @@ func defaultFetchGistSearchPage(token, query string, page int) (string, error) {
 				return string(body), nil
 			} else {
 				lastErr = fmt.Errorf("gist search returned HTTP %d", resp.StatusCode)
-				if resp.StatusCode < 500 {
+				if resp.StatusCode != http.StatusTooManyRequests && resp.StatusCode < 500 {
 					return "", lastErr
 				}
 			}

--- a/server/search/githubsearch/gists.go
+++ b/server/search/githubsearch/gists.go
@@ -1,0 +1,365 @@
+package githubsearch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v57/github"
+	"github.com/madneal/gshark/global"
+	"github.com/madneal/gshark/model"
+	"github.com/madneal/gshark/service"
+	"go.uber.org/zap"
+)
+
+const (
+	maxGistSearchPages     = 5
+	maxGistSearchPageBytes = 2 << 20
+	gistSearchTimeout      = 30 * time.Second
+	maxPublicGistFallback  = 50
+)
+
+var gistPathRe = regexp.MustCompile(`href="/(?P<owner>[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)/(?P<id>[0-9a-f]{20,32})(?:["/#?])`)
+
+var (
+	fetchGistSearchPage = defaultFetchGistSearchPage
+	gistSearchClient    = &http.Client{Timeout: gistSearchTimeout}
+)
+
+type gistHit struct {
+	Owner string
+	ID    string
+}
+
+func searchGists(client *Client, rules []model.Rule) error {
+	if len(rules) == 0 {
+		return nil
+	}
+	var content string
+	var scanErrors []error
+	for _, rule := range rules {
+		query, err := BuildGistQuery(rule.Content)
+		if err != nil {
+			global.GVA_LOG.Error("BuildGistQuery error", zap.Error(err))
+			scanErrors = append(scanErrors, fmt.Errorf("build gist query for %q: %w", rule.Content, err))
+			continue
+		}
+		hits, err := client.SearchGistHits(query)
+		if err != nil {
+			global.GVA_LOG.Error("SearchGistHits error", zap.Error(err))
+			scanErrors = append(scanErrors, fmt.Errorf("gist search %q: %w", rule.Content, err))
+			continue
+		}
+		results, err := client.LoadGistResults(hits, rule.Content)
+		if err != nil {
+			global.GVA_LOG.Error("LoadGistResults error", zap.Error(err))
+			scanErrors = append(scanErrors, fmt.Errorf("load gists for %q: %w", rule.Content, err))
+		}
+		stats := service.SaveSearchResultsWithStats(results)
+		global.GVA_LOG.Info(stats.Summary(rule.Content, "Gist"))
+		content += formatInsertedSummary(rule.Content, stats)
+	}
+	notifyNewResults("Gist 敏感信息报告", content)
+	return errors.Join(scanErrors...)
+}
+
+func (c *Client) SearchGistHits(query string) ([]gistHit, error) {
+	seen := make(map[string]struct{})
+	hits := make([]gistHit, 0)
+	for page := 1; page <= maxGistSearchPages; page++ {
+		body, err := fetchGistSearchPage(c.Token, query, page)
+		if err != nil {
+			if page == 1 {
+				global.GVA_LOG.Warn("gist HTML search failed, falling back to public gist stream", zap.Error(err))
+				return c.listRecentPublicGists()
+			}
+			break
+		}
+		pageHits := parseGistSearchHTML(body)
+		if len(pageHits) == 0 {
+			if page == 1 {
+				global.GVA_LOG.Warn("gist HTML search returned no parseable hits, falling back to public gist stream")
+				return c.listRecentPublicGists()
+			}
+			break
+		}
+		added := 0
+		for _, hit := range pageHits {
+			if _, exists := seen[hit.ID]; exists {
+				continue
+			}
+			seen[hit.ID] = struct{}{}
+			hits = append(hits, hit)
+			added++
+		}
+		if added == 0 {
+			break
+		}
+	}
+	return hits, nil
+}
+
+func (c *Client) listRecentPublicGists() ([]gistHit, error) {
+	ctx := context.Background()
+	opt := &github.GistListOptions{ListOptions: github.ListOptions{PerPage: 100}}
+	hits := make([]gistHit, 0, maxPublicGistFallback)
+	for {
+		gists, res, err := c.getPublicGists(ctx, opt)
+		if err != nil {
+			return hits, err
+		}
+		for _, gist := range gists {
+			if gist == nil || gist.GetID() == "" {
+				continue
+			}
+			hits = append(hits, gistHit{Owner: gistOwnerLogin(gist), ID: gist.GetID()})
+			if len(hits) >= maxPublicGistFallback {
+				return hits, nil
+			}
+		}
+		if res == nil || res.NextPage <= 0 {
+			return hits, nil
+		}
+		opt.Page = res.NextPage
+	}
+}
+
+func (c *Client) getPublicGists(ctx context.Context, opt *github.GistListOptions) ([]*github.Gist, *github.Response, error) {
+	for attempt := 1; attempt <= maxSearchAttempts; attempt++ {
+		gists, res, err := c.Client.Gists.ListAll(ctx, opt)
+		if err == nil {
+			c.noteSearchResponse("gists/public", res)
+			return gists, res, nil
+		}
+		if !c.recoverSearchError("gists/public", err, attempt) {
+			return nil, res, err
+		}
+	}
+	return nil, nil, errors.New("exhausted retry attempts for public gist list")
+}
+
+func (c *Client) LoadGistResults(hits []gistHit, keyword string) ([]model.SearchResult, error) {
+	results := make([]model.SearchResult, 0)
+	var loadErrors []error
+	ctx := context.Background()
+	for _, hit := range hits {
+		gist, err := c.getGist(ctx, hit.ID)
+		if err != nil {
+			loadErrors = append(loadErrors, fmt.Errorf("gist %s: %w", hit.ID, err))
+			continue
+		}
+		results = append(results, convertGistToSearchResults(gist, hit, keyword)...)
+	}
+	return results, errors.Join(loadErrors...)
+}
+
+func (c *Client) getGist(ctx context.Context, id string) (*github.Gist, error) {
+	for attempt := 1; attempt <= maxSearchAttempts; attempt++ {
+		gist, res, err := c.Client.Gists.Get(ctx, id)
+		if err == nil {
+			c.noteSearchResponse("gists/"+id, res)
+			return gist, nil
+		}
+		if !c.recoverSearchError("gists/"+id, err, attempt) {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("exhausted retry attempts for gist %s", id)
+}
+
+func convertGistToSearchResults(gist *github.Gist, hit gistHit, keyword string) []model.SearchResult {
+	if gist == nil {
+		return nil
+	}
+	owner := gistOwnerLogin(gist)
+	if owner == "" {
+		owner = hit.Owner
+	}
+	repo := strings.Trim(owner+"/"+gist.GetID(), "/")
+	if repo == "" {
+		repo = "gist/" + hit.ID
+	}
+	htmlURL := gist.GetHTMLURL()
+	if htmlURL == "" && gist.GetID() != "" {
+		htmlURL = "https://gist.github.com/" + gist.GetID()
+	}
+	results := make([]model.SearchResult, 0, len(gist.Files))
+	for filename, file := range gist.Files {
+		name := file.GetFilename()
+		if name == "" {
+			name = string(filename)
+		}
+		fragment := gistFileFragment(file.GetContent(), keyword)
+		if keyword != "" && !gistMatchesKeyword(name, gist.GetDescription(), file.GetContent(), keyword) {
+			continue
+		}
+		item := model.SearchResult{
+			Repo:    repo,
+			RepoUrl: htmlURL,
+			Keyword: keyword,
+			Path:    name,
+			Url:     htmlURL,
+			Status:  0,
+			Matches: firstLine(gist.GetDescription(), fragment),
+		}
+		if fragment != "" {
+			textMatches := []model.TextMatch{{
+				Fragment: &fragment,
+				Property: github.String("content"),
+			}}
+			if encoded, err := json.Marshal(textMatches); err != nil {
+				global.GVA_LOG.Error("json.marshal gist text matches error", zap.Error(err))
+			} else {
+				item.TextMatchesJson = encoded
+			}
+		}
+		results = append(results, item)
+	}
+	if len(results) == 0 && gist.GetDescription() != "" && gistMatchesKeyword("", gist.GetDescription(), "", keyword) {
+		results = append(results, model.SearchResult{
+			Repo:    repo,
+			RepoUrl: htmlURL,
+			Keyword: keyword,
+			Path:    "gist",
+			Url:     htmlURL,
+			Status:  0,
+			Matches: gist.GetDescription(),
+		})
+	}
+	return results
+}
+
+func gistMatchesKeyword(filename, description, content, keyword string) bool {
+	needle := strings.ToLower(strings.TrimSpace(keyword))
+	if needle == "" {
+		return true
+	}
+	// Drop filter-style tokens so "company -extension:md" still matches "company".
+	fields := strings.Fields(needle)
+	needles := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if strings.HasPrefix(field, "-") || strings.HasPrefix(field, "+") || strings.Contains(field, ":") {
+			continue
+		}
+		needles = append(needles, field)
+	}
+	if len(needles) == 0 {
+		return true
+	}
+	haystack := strings.ToLower(filename + "\n" + description + "\n" + content)
+	for _, part := range needles {
+		if !strings.Contains(haystack, part) {
+			return false
+		}
+	}
+	return true
+}
+
+func gistFileFragment(content, keyword string) string {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return ""
+	}
+	lower := strings.ToLower(content)
+	idx := strings.Index(lower, strings.ToLower(strings.TrimSpace(keyword)))
+	if idx < 0 {
+		if len(content) > 400 {
+			return content[:400]
+		}
+		return content
+	}
+	start := idx - 80
+	if start < 0 {
+		start = 0
+	}
+	end := idx + 200
+	if end > len(content) {
+		end = len(content)
+	}
+	return content[start:end]
+}
+
+func firstLine(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func gistOwnerLogin(gist *github.Gist) string {
+	if gist == nil || gist.Owner == nil {
+		return ""
+	}
+	return gist.Owner.GetLogin()
+}
+
+func parseGistSearchHTML(body string) []gistHit {
+	matches := gistPathRe.FindAllStringSubmatch(body, -1)
+	seen := make(map[string]struct{})
+	hits := make([]gistHit, 0, len(matches))
+	for _, match := range matches {
+		if len(match) < 3 {
+			continue
+		}
+		owner, id := match[1], match[2]
+		if owner == "search" || owner == "login" || owner == "join" || owner == "settings" {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		hits = append(hits, gistHit{Owner: owner, ID: id})
+	}
+	return hits
+}
+
+func defaultFetchGistSearchPage(token, query string, page int) (string, error) {
+	endpoint := fmt.Sprintf("https://gist.github.com/search?q=%s&p=%d", url.QueryEscape(strings.TrimSpace(query)), page)
+	var lastErr error
+	for attempt := 1; attempt <= maxSearchAttempts; attempt++ {
+		req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("User-Agent", "gshark")
+		req.Header.Set("Accept", "text/html")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		resp, err := gistSearchClient.Do(req)
+		if err != nil {
+			lastErr = err
+		} else {
+			limited := io.LimitReader(resp.Body, maxGistSearchPageBytes+1)
+			body, readErr := io.ReadAll(limited)
+			resp.Body.Close()
+			if readErr != nil {
+				lastErr = readErr
+			} else if len(body) > maxGistSearchPageBytes {
+				return "", fmt.Errorf("gist search page exceeded %d bytes", maxGistSearchPageBytes)
+			} else if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return string(body), nil
+			} else {
+				lastErr = fmt.Errorf("gist search returned HTTP %d", resp.StatusCode)
+				if resp.StatusCode < 500 {
+					return "", lastErr
+				}
+			}
+		}
+		if attempt < maxSearchAttempts {
+			sleepFn(time.Duration(attempt) * 2 * time.Second)
+		}
+	}
+	return "", lastErr
+}

--- a/server/search/githubsearch/issues.go
+++ b/server/search/githubsearch/issues.go
@@ -1,0 +1,148 @@
+package githubsearch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/go-github/v57/github"
+	"github.com/madneal/gshark/global"
+	"github.com/madneal/gshark/model"
+	"github.com/madneal/gshark/service"
+	"go.uber.org/zap"
+)
+
+func searchIssues(client *Client, rules []model.Rule) error {
+	if len(rules) == 0 {
+		return nil
+	}
+	var content string
+	var scanErrors []error
+	for _, rule := range rules {
+		query, err := BuildIssueQuery(rule.Content)
+		if err != nil {
+			global.GVA_LOG.Error("BuildIssueQuery error", zap.Error(err))
+			scanErrors = append(scanErrors, fmt.Errorf("build issue query for %q: %w", rule.Content, err))
+			continue
+		}
+		results, err := client.SearchIssues(query)
+		if err != nil {
+			global.GVA_LOG.Error("SearchIssues error", zap.Error(err))
+			scanErrors = append(scanErrors, fmt.Errorf("issue search %q: %w", rule.Content, err))
+			continue
+		}
+		stats := service.SaveSearchResultsWithStats(ConvertIssuesToSearchResults(results, rule.Content))
+		global.GVA_LOG.Info(stats.Summary(rule.Content, "GitHub Issue"))
+		content += formatInsertedSummary(rule.Content, stats)
+	}
+	notifyNewResults("GitHub Issue/PR 敏感信息报告", content)
+	return errors.Join(scanErrors...)
+}
+
+func (c *Client) SearchIssues(query string) ([]*github.IssuesSearchResult, error) {
+	var all []*github.IssuesSearchResult
+	ctx := context.Background()
+	opt := &github.SearchOptions{TextMatch: true, ListOptions: github.ListOptions{PerPage: 100}}
+	global.GVA_LOG.Info("GitHub issue scan with the query:", zap.String("query", query))
+	for {
+		result, nextPage := c.searchIssuesByOpt(ctx, query, *opt)
+		if result == nil {
+			return all, fmt.Errorf("GitHub returned no issue response for query %q", query)
+		}
+		all = append(all, result)
+		if nextPage <= 0 {
+			return all, nil
+		}
+		opt.Page = nextPage
+	}
+}
+
+func (c *Client) searchIssuesByOpt(ctx context.Context, query string, opt github.SearchOptions) (*github.IssuesSearchResult, int) {
+	for attempt := 1; attempt <= maxSearchAttempts; attempt++ {
+		result, res, err := c.Client.Search.Issues(ctx, query, &opt)
+		if err == nil {
+			return result, c.noteSearchResponse(query, res)
+		}
+		if !c.recoverSearchError(query, err, attempt) {
+			return nil, 0
+		}
+	}
+	global.GVA_LOG.Error("exhausted retry attempts for GitHub issue search", zap.String("query", query))
+	return nil, 0
+}
+
+func ConvertIssuesToSearchResults(results []*github.IssuesSearchResult, keyword string) []model.SearchResult {
+	searchResults := make([]model.SearchResult, 0)
+	for _, result := range results {
+		if result == nil {
+			continue
+		}
+		for _, issue := range result.Issues {
+			if issue == nil {
+				continue
+			}
+			repoName, repoURL := repoFromIssue(issue)
+			kind := "issues"
+			if issue.IsPullRequest() {
+				kind = "pull"
+			}
+			item := model.SearchResult{
+				Repo:    repoName,
+				RepoUrl: repoURL,
+				Keyword: keyword,
+				Path:    fmt.Sprintf("%s/%d", kind, issue.GetNumber()),
+				Url:     issue.GetHTMLURL(),
+				Status:  0,
+				Matches: issueSnippet(issue),
+			}
+			if len(issue.TextMatches) > 0 {
+				if encoded, err := json.Marshal(issue.TextMatches); err != nil {
+					global.GVA_LOG.Error("json.marshal issue text matches error", zap.Error(err))
+				} else {
+					item.TextMatchesJson = encoded
+				}
+			}
+			searchResults = append(searchResults, item)
+		}
+	}
+	return searchResults
+}
+
+func repoFromIssue(issue *github.Issue) (name, htmlURL string) {
+	if issue == nil {
+		return "", ""
+	}
+	if repo := issue.GetRepository(); repo != nil && repo.GetFullName() != "" {
+		name = repo.GetFullName()
+		htmlURL = repo.GetHTMLURL()
+		if htmlURL == "" && name != "" {
+			htmlURL = "https://github.com/" + name
+		}
+		return name, htmlURL
+	}
+	name = strings.TrimPrefix(issue.GetRepositoryURL(), "https://api.github.com/repos/")
+	if name == issue.GetRepositoryURL() {
+		name = ""
+	}
+	if name != "" {
+		htmlURL = "https://github.com/" + name
+	}
+	return name, htmlURL
+}
+
+func issueSnippet(issue *github.Issue) string {
+	title := strings.TrimSpace(issue.GetTitle())
+	body := strings.TrimSpace(issue.GetBody())
+	if body == "" {
+		return title
+	}
+	if len(body) > 400 {
+		body = body[:400]
+	}
+	if title == "" {
+		return body
+	}
+	return title + "\n" + body
+}

--- a/server/search/githubsearch/issues_gist_test.go
+++ b/server/search/githubsearch/issues_gist_test.go
@@ -1,0 +1,243 @@
+package githubsearch
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v57/github"
+	"github.com/madneal/gshark/model"
+)
+
+func stubFilters(t *testing.T, filters map[string][]model.Filter) {
+	t.Helper()
+	original := getFiltersByClass
+	getFiltersByClass = func(class string) (error, []model.Filter) {
+		return nil, filters[class]
+	}
+	t.Cleanup(func() { getFiltersByClass = original })
+}
+
+func TestBuildIssueQueryAddsDefaultInQualifier(t *testing.T) {
+	stubFilters(t, nil)
+	got, err := BuildIssueQuery("acme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "acme in:title,body,comments" {
+		t.Fatalf("BuildIssueQuery() = %q", got)
+	}
+}
+
+func TestBuildIssueQueryKeepsExplicitInQualifier(t *testing.T) {
+	stubFilters(t, nil)
+	got, err := BuildIssueQuery("acme in:body is:pr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "acme in:body is:pr" {
+		t.Fatalf("BuildIssueQuery() = %q", got)
+	}
+}
+
+func TestBuildIssueQueryAppliesKeywordFiltersOnly(t *testing.T) {
+	stubFilters(t, map[string][]model.Filter{
+		"extension": {{FilterType: "blacklist", Content: "md"}},
+		"keyword":   {{FilterType: "black", Content: "example"}},
+	})
+	got, err := BuildIssueQuery("acme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, " NOT example") {
+		t.Fatalf("expected keyword deny, got %q", got)
+	}
+	if strings.Contains(got, "extension:") {
+		t.Fatalf("issue query should not use extension filters, got %q", got)
+	}
+}
+
+func TestConvertIssuesToSearchResultsMapsIssueAndPull(t *testing.T) {
+	results := ConvertIssuesToSearchResults([]*github.IssuesSearchResult{{
+		Issues: []*github.Issue{
+			{
+				Number:        github.Int(12),
+				Title:         github.String("leaked token"),
+				Body:          github.String("AKIAEXAMPLE"),
+				HTMLURL:       github.String("https://github.com/acme/app/issues/12"),
+				RepositoryURL: github.String("https://api.github.com/repos/acme/app"),
+			},
+			{
+				Number:           github.Int(8),
+				Title:            github.String("add secret"),
+				HTMLURL:          github.String("https://github.com/acme/app/pull/8"),
+				RepositoryURL:    github.String("https://api.github.com/repos/acme/app"),
+				PullRequestLinks: &github.PullRequestLinks{URL: github.String("https://api.github.com/repos/acme/app/pulls/8")},
+			},
+		},
+	}}, "acme")
+
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].Path != "issues/12" || results[0].Repo != "acme/app" {
+		t.Fatalf("issue mapping = %#v", results[0])
+	}
+	if results[1].Path != "pull/8" || results[1].Url != "https://github.com/acme/app/pull/8" {
+		t.Fatalf("pull mapping = %#v", results[1])
+	}
+}
+
+func TestSearchIssuesByOptRetriesAfterRotatingOnPrimaryRateLimit(t *testing.T) {
+	stubSleep(t)
+	requestCount := 0
+	client, newGithubClient := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			writeRateLimitResponse(w, time.Now().Add(time.Hour))
+			return
+		}
+		if !strings.Contains(r.URL.Path, "/search/issues") {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		w.Header().Set("X-RateLimit-Remaining", "100")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(github.IssuesSearchResult{
+			Total: github.Int(1),
+			Issues: []*github.Issue{{
+				Number:  github.Int(1),
+				HTMLURL: github.String("https://github.com/acme/app/issues/1"),
+			}},
+		})
+	})
+	client.rotate = func() bool {
+		client.Client = newGithubClient()
+		return true
+	}
+
+	result, nextPage := client.searchIssuesByOpt(context.Background(), "acme", github.SearchOptions{})
+	if requestCount != 2 {
+		t.Fatalf("requestCount = %d, want 2", requestCount)
+	}
+	if result == nil || len(result.Issues) != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	if nextPage != 0 {
+		t.Fatalf("nextPage = %d, want 0", nextPage)
+	}
+}
+
+func TestParseGistSearchHTMLExtractsUniqueGists(t *testing.T) {
+	html := `
+<a href="/saumalya75/8ccbb1c6198b862db3ccbfac45efe27f">1 file</a>
+<a href="/saumalya75/8ccbb1c6198b862db3ccbfac45efe27f/forks">forks</a>
+<a href="/saumalya75/8ccbb1c6198b862db3ccbfac45efe27f/stargazers">stars</a>
+<a href="/guichafy/85aa619319b59a436c679cc14fc7954f">other</a>
+<a href="/search?q=aws">search</a>
+`
+	hits := parseGistSearchHTML(html)
+	if len(hits) != 2 {
+		t.Fatalf("hits = %#v", hits)
+	}
+	if hits[0].Owner != "saumalya75" || hits[0].ID != "8ccbb1c6198b862db3ccbfac45efe27f" {
+		t.Fatalf("first hit = %#v", hits[0])
+	}
+	if hits[1].ID != "85aa619319b59a436c679cc14fc7954f" {
+		t.Fatalf("second hit = %#v", hits[1])
+	}
+}
+
+func TestGistMatchesKeywordIgnoresQualifiers(t *testing.T) {
+	if !gistMatchesKeyword("config.env", "", "company token", "company -extension:md") {
+		t.Fatal("expected keyword match after dropping gist qualifiers")
+	}
+	if gistMatchesKeyword("readme.md", "", "nothing here", "company") {
+		t.Fatal("expected no match")
+	}
+}
+
+func TestConvertGistToSearchResultsKeepsMatchingFiles(t *testing.T) {
+	gist := &github.Gist{
+		ID:      github.String("8ccbb1c6198b862db3ccbfac45efe27f"),
+		HTMLURL: github.String("https://gist.github.com/acme/8ccbb1c6198b862db3ccbfac45efe27f"),
+		Owner:   &github.User{Login: github.String("acme")},
+		Files: map[github.GistFilename]github.GistFile{
+			"secrets.env": {Filename: github.String("secrets.env"), Content: github.String("password=acme-prod")},
+			"readme.md":   {Filename: github.String("readme.md"), Content: github.String("unrelated")},
+		},
+	}
+	results := convertGistToSearchResults(gist, gistHit{Owner: "acme", ID: gist.GetID()}, "acme")
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1, got %#v", len(results), results)
+	}
+	if results[0].Repo != "acme/8ccbb1c6198b862db3ccbfac45efe27f" {
+		t.Fatalf("repo = %q", results[0].Repo)
+	}
+	if results[0].Path != "secrets.env" {
+		t.Fatalf("path = %q", results[0].Path)
+	}
+}
+
+func TestSearchGistHitsUsesHTMLThenStopsOnRepeatPage(t *testing.T) {
+	original := fetchGistSearchPage
+	t.Cleanup(func() { fetchGistSearchPage = original })
+	pages := 0
+	fetchGistSearchPage = func(_, _ string, page int) (string, error) {
+		pages++
+		return `<a href="/acme/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">gist</a>`, nil
+	}
+
+	client := &Client{Token: "test-token"}
+	hits, err := client.SearchGistHits("acme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 || hits[0].ID != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Fatalf("hits = %#v", hits)
+	}
+	if pages != 2 {
+		t.Fatalf("expected a second page to detect duplicates, got %d fetches", pages)
+	}
+}
+
+func TestRunTaskSkipsWhenNoGithubSurfacesEnabled(t *testing.T) {
+	original := getGithubRules
+	getGithubRules = func(string) (error, []model.Rule) { return nil, nil }
+	t.Cleanup(func() { getGithubRules = original })
+
+	slept := stubSleep(t)
+	outcome := RunTask()
+	if len(*slept) != 0 {
+		t.Fatalf("RunTask slept without rules: %v", *slept)
+	}
+	if outcome.Status != model.ScanStatusSkipped {
+		t.Fatalf("status = %q, want skipped", outcome.Status)
+	}
+}
+
+func TestRunTaskFailsWithoutTokenWhenIssueRulesExist(t *testing.T) {
+	originalRules := getGithubRules
+	getGithubRules = func(ruleType string) (error, []model.Rule) {
+		if ruleType == "github_issue" {
+			return nil, []model.Rule{{Content: "acme"}}
+		}
+		return nil, nil
+	}
+	originalTokens := listGithubTokens
+	listGithubTokens = func(string) (error, []model.Token) { return nil, nil }
+	t.Cleanup(func() {
+		getGithubRules = originalRules
+		listGithubTokens = originalTokens
+	})
+
+	outcome := RunTask()
+	if outcome.Status != model.ScanStatusFailed {
+		t.Fatalf("status = %q, want failed", outcome.Status)
+	}
+	if !strings.Contains(outcome.Message, "token") && !strings.Contains(outcome.Message, "client") {
+		t.Fatalf("message = %q", outcome.Message)
+	}
+}

--- a/server/search/githubsearch/issues_gist_test.go
+++ b/server/search/githubsearch/issues_gist_test.go
@@ -3,6 +3,7 @@ package githubsearch
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -39,6 +40,17 @@ func TestBuildIssueQueryKeepsExplicitInQualifier(t *testing.T) {
 		t.Fatal(err)
 	}
 	if got != "acme in:body is:pr" {
+		t.Fatalf("BuildIssueQuery() = %q", got)
+	}
+}
+
+func TestBuildIssueQueryIgnoresInInsideOtherTokens(t *testing.T) {
+	stubFilters(t, nil)
+	got, err := BuildIssueQuery("login:admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "login:admin in:title,body,comments" {
 		t.Fatalf("BuildIssueQuery() = %q", got)
 	}
 }
@@ -159,7 +171,17 @@ func TestGistMatchesKeywordIgnoresQualifiers(t *testing.T) {
 	}
 }
 
+func TestGistMatchesKeywordKeepsColonNeedles(t *testing.T) {
+	if !gistMatchesKeyword("secrets.env", "", "aws_access_key_id: AKIA", "aws_access_key_id:") {
+		t.Fatal("expected a colon-bearing secret token to remain a needle")
+	}
+	if gistMatchesKeyword("secrets.env", "", "unrelated", "aws_access_key_id:") {
+		t.Fatal("expected colon-bearing needle to require a match")
+	}
+}
+
 func TestConvertGistToSearchResultsKeepsMatchingFiles(t *testing.T) {
+	stubFilters(t, nil)
 	gist := &github.Gist{
 		ID:      github.String("8ccbb1c6198b862db3ccbfac45efe27f"),
 		HTMLURL: github.String("https://gist.github.com/acme/8ccbb1c6198b862db3ccbfac45efe27f"),
@@ -181,11 +203,30 @@ func TestConvertGistToSearchResultsKeepsMatchingFiles(t *testing.T) {
 	}
 }
 
+func TestConvertGistToSearchResultsAppliesExtensionFilters(t *testing.T) {
+	stubFilters(t, map[string][]model.Filter{
+		"extension": {{FilterType: "blacklist", Content: "md"}},
+	})
+	gist := &github.Gist{
+		ID:      github.String("8ccbb1c6198b862db3ccbfac45efe27f"),
+		HTMLURL: github.String("https://gist.github.com/acme/8ccbb1c6198b862db3ccbfac45efe27f"),
+		Owner:   &github.User{Login: github.String("acme")},
+		Files: map[github.GistFilename]github.GistFile{
+			"secrets.env": {Filename: github.String("secrets.env"), Content: github.String("acme token")},
+			"notes.md":    {Filename: github.String("notes.md"), Content: github.String("acme token")},
+		},
+	}
+	results := convertGistToSearchResults(gist, gistHit{Owner: "acme", ID: gist.GetID()}, "acme")
+	if len(results) != 1 || results[0].Path != "secrets.env" {
+		t.Fatalf("results = %#v", results)
+	}
+}
+
 func TestSearchGistHitsUsesHTMLThenStopsOnRepeatPage(t *testing.T) {
 	original := fetchGistSearchPage
 	t.Cleanup(func() { fetchGistSearchPage = original })
 	pages := 0
-	fetchGistSearchPage = func(_, _ string, page int) (string, error) {
+	fetchGistSearchPage = func(_ string, page int) (string, error) {
 		pages++
 		return `<a href="/acme/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">gist</a>`, nil
 	}
@@ -200,6 +241,55 @@ func TestSearchGistHitsUsesHTMLThenStopsOnRepeatPage(t *testing.T) {
 	}
 	if pages != 2 {
 		t.Fatalf("expected a second page to detect duplicates, got %d fetches", pages)
+	}
+}
+
+func TestSearchGistHitsEmptyHTMLDoesNotFallback(t *testing.T) {
+	original := fetchGistSearchPage
+	t.Cleanup(func() { fetchGistSearchPage = original })
+	fetchGistSearchPage = func(string, int) (string, error) {
+		return `<html><title>Search</title></html>`, nil
+	}
+
+	hits, err := (&Client{}).SearchGistHits("password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("hits = %#v", hits)
+	}
+}
+
+func TestSearchGistHitsHTTPErrorDoesNotFallback(t *testing.T) {
+	original := fetchGistSearchPage
+	t.Cleanup(func() { fetchGistSearchPage = original })
+	fetchGistSearchPage = func(string, int) (string, error) {
+		return "", errors.New("gist search returned HTTP 401")
+	}
+
+	hits, err := (&Client{}).SearchGistHits("password")
+	if err == nil {
+		t.Fatal("expected HTML search error")
+	}
+	if hits != nil {
+		t.Fatalf("hits = %#v", hits)
+	}
+}
+
+func TestGetGistSkipsNotFoundWithoutSleep(t *testing.T) {
+	slept := stubSleep(t)
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "100")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "Not Found"})
+	})
+
+	gist, err := client.getGist(context.Background(), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	if err == nil || gist != nil {
+		t.Fatalf("expected not-found, got gist=%#v err=%v", gist, err)
+	}
+	if len(*slept) != 0 {
+		t.Fatalf("getGist slept on 404: %v", *slept)
 	}
 }
 

--- a/server/search/githubsearch/search.go
+++ b/server/search/githubsearch/search.go
@@ -27,6 +27,13 @@ func Search(rules []model.Rule) error {
 		global.GVA_LOG.Error("GetGithubClient err", zap.Error(err))
 		return err
 	}
+	return searchCode(client, rules)
+}
+
+func searchCode(client *Client, rules []model.Rule) error {
+	if len(rules) == 0 {
+		return nil
+	}
 	var content string
 	var scanErrors []error
 	for _, rule := range rules {
@@ -44,34 +51,41 @@ func Search(rules []model.Rule) error {
 		}
 		stats := SaveResultWithStats(results, rule.Content)
 		global.GVA_LOG.Info(stats.Summary(rule.Content, "GitHub"))
-		if stats.Inserted > 0 {
-			repoInfo := ""
-			if len(stats.Repos) > 0 {
-				if len(stats.Repos) <= 3 {
-					repoInfo = fmt.Sprintf(" (repos: %s)", strings.Join(stats.Repos, ", "))
-				} else {
-					repoInfo = fmt.Sprintf(" (repos: %s +%d more)", strings.Join(stats.Repos[:3], ", "), len(stats.Repos)-3)
-				}
-			}
-			content += fmt.Sprintf("%s: %d条%s<br>", rule.Content, stats.Inserted, repoInfo)
-		}
+		content += formatInsertedSummary(rule.Content, stats)
 	}
-	if content != "" {
-		if global.GVA_CONFIG.Email.Enable {
-			err = utils.EmailSend("Github敏感信息报告", content)
-			if err != nil {
-				global.GVA_LOG.Error("send email error", zap.Any("err", err))
-			}
-		}
-		if global.GVA_CONFIG.Wechat.Enable {
-			content = "Github敏感信息报告\n" + content
-			err = utils.BotSend(content)
-			if err != nil {
-				global.GVA_LOG.Error("send wechat error", zap.Any("err", err))
-			}
-		}
-	}
+	notifyNewResults("Github敏感信息报告", content)
 	return errors.Join(scanErrors...)
+}
+
+func formatInsertedSummary(keyword string, stats *service.SaveResultStats) string {
+	if stats == nil || stats.Inserted == 0 {
+		return ""
+	}
+	repoInfo := ""
+	if len(stats.Repos) > 0 {
+		if len(stats.Repos) <= 3 {
+			repoInfo = fmt.Sprintf(" (repos: %s)", strings.Join(stats.Repos, ", "))
+		} else {
+			repoInfo = fmt.Sprintf(" (repos: %s +%d more)", strings.Join(stats.Repos[:3], ", "), len(stats.Repos)-3)
+		}
+	}
+	return fmt.Sprintf("%s: %d条%s<br>", keyword, stats.Inserted, repoInfo)
+}
+
+func notifyNewResults(title, content string) {
+	if content == "" {
+		return
+	}
+	if global.GVA_CONFIG.Email.Enable {
+		if err := utils.EmailSend(title, content); err != nil {
+			global.GVA_LOG.Error("send email error", zap.Any("err", err))
+		}
+	}
+	if global.GVA_CONFIG.Wechat.Enable {
+		if err := utils.BotSend(title + "\n" + content); err != nil {
+			global.GVA_LOG.Error("send wechat error", zap.Any("err", err))
+		}
+	}
 }
 
 func SaveResultWithStats(results []*github.CodeSearchResult, keyword string) *service.SaveResultStats {
@@ -106,22 +120,52 @@ func ConvertToSearchResults(results []*github.CodeSearchResult, keyword string) 
 }
 
 func RunTask() model.ScanOutcome {
-	err, rules := getGithubRules("github")
+	err, codeRules := getGithubRules("github")
 	if err != nil {
 		global.GVA_LOG.Error("GetValidRulesByType github err", zap.Error(err))
 		return model.ScanFailed("Failed to load GitHub rules: " + err.Error())
 	}
-	color.Debug.Print(fmt.Sprintf("Github fetch %d rules, begin the scan task\n", len(rules)))
-	if len(rules) == 0 {
-		message := "No enabled GitHub rules; provider skipped"
+	err, issueRules := getGithubRules("github_issue")
+	if err != nil {
+		global.GVA_LOG.Error("GetValidRulesByType github_issue err", zap.Error(err))
+		return model.ScanFailed("Failed to load GitHub issue rules: " + err.Error())
+	}
+	err, gistRules := getGithubRules("gist")
+	if err != nil {
+		global.GVA_LOG.Error("GetValidRulesByType gist err", zap.Error(err))
+		return model.ScanFailed("Failed to load Gist rules: " + err.Error())
+	}
+
+	color.Debug.Print(fmt.Sprintf("Github fetch %d code / %d issue / %d gist rules\n",
+		len(codeRules), len(issueRules), len(gistRules)))
+	if len(codeRules) == 0 && len(issueRules) == 0 && len(gistRules) == 0 {
+		message := "No enabled GitHub, issue, or gist rules; provider skipped"
 		global.GVA_LOG.Info(message)
 		return model.ScanSkipped(message)
 	}
-	if err := Search(rules); err != nil {
+
+	client, err := GetGithubClient()
+	if err != nil {
+		global.GVA_LOG.Error("GetGithubClient err", zap.Error(err))
+		return model.ScanFailed("GitHub client initialization failed: " + err.Error())
+	}
+
+	var scanErrors []error
+	if err := searchCode(client, codeRules); err != nil {
+		scanErrors = append(scanErrors, err)
+	}
+	if err := searchIssues(client, issueRules); err != nil {
+		scanErrors = append(scanErrors, err)
+	}
+	if err := searchGists(client, gistRules); err != nil {
+		scanErrors = append(scanErrors, err)
+	}
+	if err := errors.Join(scanErrors...); err != nil {
 		return model.ScanFailed("GitHub scan completed with errors: " + err.Error())
 	}
 	color.Debug.Print("Complete the scan of Github\n")
-	return model.ScanSuccess(fmt.Sprintf("Completed %d GitHub rules", len(rules)))
+	return model.ScanSuccess(fmt.Sprintf("Completed %d code, %d issue, %d gist rules",
+		len(codeRules), len(issueRules), len(gistRules)))
 }
 
 func (c *Client) GetCommiter(ctx context.Context, owner, repo string) string {
@@ -157,43 +201,77 @@ func (c *Client) SearchCode(query string) ([]*github.CodeSearchResult, error) {
 
 func BuildQuery(query string) (string, error) {
 	query = query + " in:file"
-	err, extensionFilters := model.GetFilterByClass("extension")
+	ext, err := appendExtensionFilters("", " -extension:", " +extension:")
 	if err != nil {
-		return query, err
+		return query + ext, err
 	}
-	// if there is no record, does not return err
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return query, nil
+	kw, err := appendKeywordFilters("", " NOT ", " ")
+	return query + ext + kw, err
+}
+
+func BuildIssueQuery(query string) (string, error) {
+	if !strings.Contains(query, "in:") {
+		query += " in:title,body,comments"
 	}
-	str := ""
+	return appendKeywordFilters(query, " NOT ", " ")
+}
+
+func BuildGistQuery(query string) (string, error) {
+	ext, err := appendExtensionFilters("", " -extension:", " extension:")
+	if err != nil {
+		return query + ext, err
+	}
+	kw, err := appendKeywordFilters("", " -", " ")
+	return query + ext + kw, err
+}
+
+func appendExtensionFilters(str, denyPrefix, allowPrefix string) (string, error) {
+	err, extensionFilters := getFiltersByClass("extension")
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return str, nil
+		}
+		return str, err
+	}
 	for _, extensionFilter := range extensionFilters {
 		extensions := strings.Split(extensionFilter.Content, ",")
 		filterType := extensionFilter.FilterType
 		for _, extension := range extensions {
+			extension = strings.TrimSpace(extension)
+			if extension == "" {
+				continue
+			}
 			if filterType == "blacklist" {
-				str += " -extension:" + extension
+				str += denyPrefix + extension
 			} else {
-				str += " +extension:" + extension
+				str += allowPrefix + extension
 			}
 		}
 	}
+	return str, nil
+}
 
-	err, keywordFilters := model.GetFilterByClass("keyword")
-
+func appendKeywordFilters(str, denyPrefix, allowPrefix string) (string, error) {
+	err, keywordFilters := getFiltersByClass("keyword")
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return str, err
+	}
 	for _, keywordFilter := range keywordFilters {
 		keywords := strings.Split(keywordFilter.Content, ",")
 		filterType := keywordFilter.FilterType
 		for _, keyword := range keywords {
-			if filterType == "black" {
-				str += " NOT " + keyword
+			keyword = strings.TrimSpace(keyword)
+			if keyword == "" {
+				continue
+			}
+			if filterType == "black" || filterType == "blacklist" {
+				str += denyPrefix + keyword
 			} else {
-				str += " " + keyword
+				str += allowPrefix + keyword
 			}
 		}
 	}
-
-	builtQuery := query + str
-	return builtQuery, err
+	return str, nil
 }
 
 // maxSearchAttempts bounds how many times a single page is retried after
@@ -206,30 +284,16 @@ var sleepFn = time.Sleep
 
 var getGithubRules = service.GetValidRulesByType
 
+var getFiltersByClass = model.GetFilterByClass
+
 func (c *Client) searchCodeByOpt(ctx context.Context, query string, opt github.SearchOptions) (*github.CodeSearchResult,
 	int) {
 	for attempt := 1; attempt <= maxSearchAttempts; attempt++ {
 		result, res, err := c.Client.Search.Code(ctx, query, &opt)
 		if err == nil {
-			return c.afterSearchSuccess(query, result, res)
+			return result, c.noteSearchResponse(query, res)
 		}
-
-		var rateLimitError *github.RateLimitError
-		var abuseRateLimitError *github.AbuseRateLimitError
-		switch {
-		case errors.As(err, &rateLimitError):
-			global.GVA_LOG.Warn("Trigger the github rate limit", zap.Int("attempt", attempt))
-			if !c.attemptRotate() {
-				sleepUntil(rateLimitError.Rate.Reset.Time)
-			}
-		case errors.As(err, &abuseRateLimitError):
-			global.GVA_LOG.Warn("Trigger the github secondary rate limit", zap.Int("attempt", attempt))
-			if !c.attemptRotate() {
-				sleepForAbuse(abuseRateLimitError.RetryAfter)
-			}
-		default:
-			global.GVA_LOG.Error("Search error", zap.Any("github search error", err))
-			sleepFn(30 * time.Second)
+		if !c.recoverSearchError(query, err, attempt) {
 			return nil, 0
 		}
 	}
@@ -238,10 +302,33 @@ func (c *Client) searchCodeByOpt(ctx context.Context, query string, opt github.S
 	return nil, 0
 }
 
-func (c *Client) afterSearchSuccess(query string, result *github.CodeSearchResult, res *github.Response) (*github.CodeSearchResult, int) {
+func (c *Client) recoverSearchError(query string, err error, attempt int) bool {
+	var rateLimitError *github.RateLimitError
+	var abuseRateLimitError *github.AbuseRateLimitError
+	switch {
+	case errors.As(err, &rateLimitError):
+		global.GVA_LOG.Warn("Trigger the github rate limit", zap.Int("attempt", attempt), zap.String("query", query))
+		if !c.attemptRotate() {
+			sleepUntil(rateLimitError.Rate.Reset.Time)
+		}
+		return true
+	case errors.As(err, &abuseRateLimitError):
+		global.GVA_LOG.Warn("Trigger the github secondary rate limit", zap.Int("attempt", attempt), zap.String("query", query))
+		if !c.attemptRotate() {
+			sleepForAbuse(abuseRateLimitError.RetryAfter)
+		}
+		return true
+	default:
+		global.GVA_LOG.Error("Search error", zap.Any("github search error", err), zap.String("query", query))
+		sleepFn(30 * time.Second)
+		return false
+	}
+}
+
+func (c *Client) noteSearchResponse(query string, res *github.Response) int {
 	if res == nil {
 		global.GVA_LOG.Error("Received nil response from GitHub API")
-		return nil, 0
+		return 0
 	}
 
 	if res.Rate.Remaining < 3 {
@@ -252,7 +339,7 @@ func (c *Client) afterSearchSuccess(query string, result *github.CodeSearchResul
 	global.GVA_LOG.Info("Search for "+query, zap.Any("remaining", res.Rate.Remaining), zap.Any("nextPage",
 		res.NextPage), zap.Any("lastPage", res.LastPage))
 
-	return result, res.NextPage
+	return res.NextPage
 }
 
 // attemptRotate switches to the next configured github token and reports

--- a/server/search/githubsearch/search.go
+++ b/server/search/githubsearch/search.go
@@ -210,10 +210,20 @@ func BuildQuery(query string) (string, error) {
 }
 
 func BuildIssueQuery(query string) (string, error) {
-	if !strings.Contains(query, "in:") {
+	if !hasSearchQualifier(query, "in:") {
 		query += " in:title,body,comments"
 	}
 	return appendKeywordFilters(query, " NOT ", " ")
+}
+
+func hasSearchQualifier(query, prefix string) bool {
+	prefix = strings.ToLower(prefix)
+	for _, field := range strings.Fields(query) {
+		if strings.HasPrefix(strings.ToLower(field), prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func BuildGistQuery(query string) (string, error) {

--- a/web/src/view/rule/rule.vue
+++ b/web/src/view/rule/rule.vue
@@ -102,7 +102,7 @@
         <el-form-item label="规则类型:" required>
           <el-checkbox-group v-model="formData.ruleType">
             <el-checkbox v-for="ruleType in types" :label="ruleType" :key="ruleType">
-              {{ ruleType }}
+              {{ typeLabels[ruleType] || ruleType }}
             </el-checkbox>
           </el-checkbox-group>
         </el-form-item>
@@ -158,7 +158,16 @@ export default {
         desc: "",
         status: true,
       },
-      types: ["github", "gitlab", "sourcegraph", "domain", "postman"],
+      types: ["github", "github_issue", "gist", "gitlab", "sourcegraph", "domain", "postman"],
+      typeLabels: {
+        github: "github",
+        github_issue: "github issue/pr",
+        gist: "gist",
+        gitlab: "gitlab",
+        sourcegraph: "sourcegraph",
+        domain: "domain",
+        postman: "postman",
+      },
     };
   },
   methods: {


### PR DESCRIPTION
## Summary
- Reuse the existing GitHub token to search **issues and pull requests** via the official Search API (`github_issue` rules).
- Add **public Gist** coverage (`gist` rules): parse gist search hits, then load file contents through the official Gist API. If HTML search is unavailable, fall back to the recent public gist stream and keyword-match locally.
- One rule can enable `github`, `github_issue`, and `gist` together. Keyword filters apply to all three; extension filters apply to code and gist.
- Add unit tests for query building, issue/gist result mapping, HTML parsing, and rate-limit retry.

## Test plan
- [x] `go test ./search/githubsearch`
- [x] `go test ./search`
- [x] `go vet ./search/githubsearch` and `go build .`
- [ ] Create a `github_issue` rule with a known public keyword and confirm Issue/PR hits appear in search results.
- [ ] Create a `gist` rule and confirm matching gist files are saved with a usable gist URL.
- [ ] Confirm existing `github` code search still runs when only code rules are enabled.
- [ ] Confirm the scanner skips when none of `github` / `github_issue` / `gist` are enabled, and fails clearly if those rules exist but no GitHub token is configured.