### PR TITLE
fix(scanner): bound memory without task timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ cd gshark
 > [!IMPORTANT]
 > The quick Docker script starts MySQL first, initializes the database, and only then starts the scanner when `--with-scan` is used. If you start the scanner manually with Docker Compose, wait until database initialization completes first.
 
-The scanner container has conservative resource guardrails in `docker-compose.yaml`: a 512 MB memory limit, a 1 CPU limit, and Go's `GOMEMLIMIT=384MiB`. Scan results are persisted page by page so a large repository search does not remain fully resident in memory. Monitor the actual usage with `docker stats gshark-scanner` before lowering the limits further.
+The scanner container has conservative resource guardrails in `docker-compose.yaml`: a 512 MB memory limit, a 1 CPU limit, and Go's `GOMEMLIMIT=384MiB`. Scan results are persisted page by page so a large repository search does not remain fully resident in memory. If the scanner is OOM-killed, Compose restarts it automatically; monitor the actual usage with `docker stats gshark-scanner` before lowering the limits further.
 
 ## Local Deployment 
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ cd gshark
 > [!IMPORTANT]
 > The quick Docker script starts MySQL first, initializes the database, and only then starts the scanner when `--with-scan` is used. If you start the scanner manually with Docker Compose, wait until database initialization completes first.
 
+The scanner container has conservative resource guardrails in `docker-compose.yaml`: a 512 MB memory limit, a 1 CPU limit, and Go's `GOMEMLIMIT=384MiB`. Scan results are persisted page by page so a large repository search does not remain fully resident in memory. Monitor the actual usage with `docker stats gshark-scanner` before lowering the limits further.
+
 ## Local Deployment 
 
 ```bash  

--- a/README_CN.md
+++ b/README_CN.md
@@ -80,6 +80,8 @@ cd gshark
 > [!IMPORTANT]
 > Docker quick 脚本会先启动 MySQL、初始化数据库，只有使用 `--with-scan` 时才会在初始化完成后启动扫描器。如果手动使用 Docker Compose 启动扫描器，请先等待数据库初始化完成。
 
+扫描器在 `docker-compose.yaml` 中默认配置了资源保护：内存上限 512 MB、CPU 上限 1 核，并通过 `GOMEMLIMIT=384MiB` 让 Go 更积极地回收内存。搜索结果会按分页写入数据库，避免大规模搜索结果全部驻留内存。可以先使用 `docker stats gshark-scanner` 观察实际占用，再决定是否继续下调限制。
+
 ## 本地部署
 
 ```bash

--- a/README_CN.md
+++ b/README_CN.md
@@ -80,7 +80,7 @@ cd gshark
 > [!IMPORTANT]
 > Docker quick 脚本会先启动 MySQL、初始化数据库，只有使用 `--with-scan` 时才会在初始化完成后启动扫描器。如果手动使用 Docker Compose 启动扫描器，请先等待数据库初始化完成。
 
-扫描器在 `docker-compose.yaml` 中默认配置了资源保护：内存上限 512 MB、CPU 上限 1 核，并通过 `GOMEMLIMIT=384MiB` 让 Go 更积极地回收内存。搜索结果会按分页写入数据库，避免大规模搜索结果全部驻留内存。可以先使用 `docker stats gshark-scanner` 观察实际占用，再决定是否继续下调限制。
+扫描器在 `docker-compose.yaml` 中默认配置了资源保护：内存上限 512 MB、CPU 上限 1 核，并通过 `GOMEMLIMIT=384MiB` 让 Go 更积极地回收内存。搜索结果会按分页写入数据库，避免大规模搜索结果全部驻留内存。如果 scanner 因超过内存上限被 OOM kill，Compose 会自动重启；可以先使用 `docker stats gshark-scanner` 观察实际占用，再决定是否继续下调限制。
 
 ## 本地部署
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -72,7 +72,14 @@ services:
       dockerfile: deploy/scan/Dockerfile
     environment:
       - GSHARK_CONFIG=config.docker.yaml
+      - GOMEMLIMIT=384MiB
+      - GOGC=75
+      - GOMAXPROCS=1
     container_name: gshark-scanner
+    mem_limit: 512m
+    mem_reservation: 256m
+    cpus: "1.0"
+    pids_limit: 128
     volumes:
       - ./server/config.docker.yaml:/go/src/github.com/madneal/gshark/server/config.docker.yaml
     restart: "no"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -82,7 +82,7 @@ services:
     pids_limit: 128
     volumes:
       - ./server/config.docker.yaml:/go/src/github.com/madneal/gshark/server/config.docker.yaml
-    restart: "no"
+    restart: "always"
     depends_on:
       mysql:
         condition: service_healthy

--- a/server/search/githubsearch/gitclient.go
+++ b/server/search/githubsearch/gitclient.go
@@ -8,9 +8,12 @@ import (
 	"github.com/madneal/gshark/global"
 	"go.uber.org/zap"
 	"net/http"
+	"time"
 
 	"github.com/madneal/gshark/service"
 )
+
+const githubRequestTimeout = 2 * time.Minute
 
 type Client struct {
 	Client *github.Client
@@ -32,7 +35,10 @@ func InitClient(token string) *Client {
 }
 
 func InitGithubClient(token string) *github.Client {
-	httpClient := &http.Client{Transport: newGithubHTTPTransport()}
+	httpClient := &http.Client{
+		Transport: newGithubHTTPTransport(),
+		Timeout:   githubRequestTimeout,
+	}
 	gitClient := github.NewClient(httpClient).WithAuthToken(token)
 	return gitClient
 }

--- a/server/search/githubsearch/search.go
+++ b/server/search/githubsearch/search.go
@@ -38,10 +38,13 @@ func Search(rules []model.Rule) error {
 		}
 		var ruleInserted int
 		var ruleRepos []string
+		var ruleHasMoreRepos bool
 		err = client.SearchCodeStream(query, func(page []*github.CodeSearchResult) error {
 			stats := SaveResultWithStats(page, rule.Content)
 			ruleInserted += stats.Inserted
-			ruleRepos = appendUniqueRepos(ruleRepos, stats.Repos)
+			var more bool
+			ruleRepos, more = appendUniqueRepos(ruleRepos, stats.Repos)
+			ruleHasMoreRepos = ruleHasMoreRepos || more
 			return nil
 		})
 		if err != nil {
@@ -53,10 +56,9 @@ func Search(rules []model.Rule) error {
 		if ruleInserted > 0 {
 			repoInfo := ""
 			if len(ruleRepos) > 0 {
-				if len(ruleRepos) <= 3 {
-					repoInfo = fmt.Sprintf(" (repos: %s)", strings.Join(ruleRepos, ", "))
-				} else {
-					repoInfo = fmt.Sprintf(" (repos: %s +%d more)", strings.Join(ruleRepos[:3], ", "), len(ruleRepos)-3)
+				repoInfo = fmt.Sprintf(" (repos: %s)", strings.Join(ruleRepos, ", "))
+				if ruleHasMoreRepos {
+					repoInfo += " +more"
 				}
 			}
 			content += fmt.Sprintf("%s: %d条%s<br>", rule.Content, ruleInserted, repoInfo)
@@ -85,19 +87,27 @@ func SaveResultWithStats(results []*github.CodeSearchResult, keyword string) *se
 	return service.SaveSearchResultsWithStats(searchResults)
 }
 
-func appendUniqueRepos(existing []string, repos []string) []string {
-	seen := make(map[string]struct{}, len(existing)+len(repos))
-	for _, repo := range existing {
-		seen[repo] = struct{}{}
-	}
+func appendUniqueRepos(existing []string, repos []string) ([]string, bool) {
+	const previewLimit = 3
+	hasMore := false
 	for _, repo := range repos {
-		if _, ok := seen[repo]; ok {
+		duplicate := false
+		for _, current := range existing {
+			if current == repo {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
 			continue
 		}
-		seen[repo] = struct{}{}
-		existing = append(existing, repo)
+		if len(existing) < previewLimit {
+			existing = append(existing, repo)
+		} else {
+			hasMore = true
+		}
 	}
-	return existing
+	return existing, hasMore
 }
 
 func ConvertToSearchResults(results []*github.CodeSearchResult, keyword string) []model.SearchResult {

--- a/server/search/githubsearch/search.go
+++ b/server/search/githubsearch/search.go
@@ -36,24 +36,30 @@ func Search(rules []model.Rule) error {
 			scanErrors = append(scanErrors, fmt.Errorf("build query for %q: %w", rule.Content, err))
 			continue
 		}
-		results, err := client.SearchCode(query)
+		var ruleInserted int
+		var ruleRepos []string
+		err = client.SearchCodeStream(query, func(page []*github.CodeSearchResult) error {
+			stats := SaveResultWithStats(page, rule.Content)
+			ruleInserted += stats.Inserted
+			ruleRepos = appendUniqueRepos(ruleRepos, stats.Repos)
+			return nil
+		})
 		if err != nil {
 			global.GVA_LOG.Error("SearchCode error", zap.Error(err))
 			scanErrors = append(scanErrors, fmt.Errorf("search %q: %w", rule.Content, err))
 			continue
 		}
-		stats := SaveResultWithStats(results, rule.Content)
-		global.GVA_LOG.Info(stats.Summary(rule.Content, "GitHub"))
-		if stats.Inserted > 0 {
+		global.GVA_LOG.Info(fmt.Sprintf("[GitHub] keyword=%q: inserted=%d", rule.Content, ruleInserted))
+		if ruleInserted > 0 {
 			repoInfo := ""
-			if len(stats.Repos) > 0 {
-				if len(stats.Repos) <= 3 {
-					repoInfo = fmt.Sprintf(" (repos: %s)", strings.Join(stats.Repos, ", "))
+			if len(ruleRepos) > 0 {
+				if len(ruleRepos) <= 3 {
+					repoInfo = fmt.Sprintf(" (repos: %s)", strings.Join(ruleRepos, ", "))
 				} else {
-					repoInfo = fmt.Sprintf(" (repos: %s +%d more)", strings.Join(stats.Repos[:3], ", "), len(stats.Repos)-3)
+					repoInfo = fmt.Sprintf(" (repos: %s +%d more)", strings.Join(ruleRepos[:3], ", "), len(ruleRepos)-3)
 				}
 			}
-			content += fmt.Sprintf("%s: %d条%s<br>", rule.Content, stats.Inserted, repoInfo)
+			content += fmt.Sprintf("%s: %d条%s<br>", rule.Content, ruleInserted, repoInfo)
 		}
 	}
 	if content != "" {
@@ -77,6 +83,21 @@ func Search(rules []model.Rule) error {
 func SaveResultWithStats(results []*github.CodeSearchResult, keyword string) *service.SaveResultStats {
 	searchResults := ConvertToSearchResults(results, keyword)
 	return service.SaveSearchResultsWithStats(searchResults)
+}
+
+func appendUniqueRepos(existing []string, repos []string) []string {
+	seen := make(map[string]struct{}, len(existing)+len(repos))
+	for _, repo := range existing {
+		seen[repo] = struct{}{}
+	}
+	for _, repo := range repos {
+		if _, ok := seen[repo]; ok {
+			continue
+		}
+		seen[repo] = struct{}{}
+		existing = append(existing, repo)
+	}
+	return existing
 }
 
 func ConvertToSearchResults(results []*github.CodeSearchResult, keyword string) []model.SearchResult {
@@ -135,7 +156,17 @@ func (c *Client) GetCommiter(ctx context.Context, owner, repo string) string {
 
 func (c *Client) SearchCode(query string) ([]*github.CodeSearchResult, error) {
 	var allSearchResult []*github.CodeSearchResult
-	var err error
+	err := c.SearchCodeStream(query, func(page []*github.CodeSearchResult) error {
+		allSearchResult = append(allSearchResult, page...)
+		return nil
+	})
+	return allSearchResult, err
+}
+
+// SearchCodeStream fetches GitHub search pages one at a time. The callback is
+// invoked before the next page is requested so callers can persist each page
+// and keep the result set out of memory.
+func (c *Client) SearchCodeStream(query string, onPage func([]*github.CodeSearchResult) error) error {
 	ctx := context.Background()
 	listOpt := github.ListOptions{PerPage: 100}
 	opt := &github.SearchOptions{TextMatch: true, ListOptions: listOpt}
@@ -143,16 +174,17 @@ func (c *Client) SearchCode(query string) ([]*github.CodeSearchResult, error) {
 	for {
 		result, nextPage := c.searchCodeByOpt(ctx, query, *opt)
 		if result == nil {
-			err = fmt.Errorf("GitHub returned no response for query %q", query)
-			break
+			return fmt.Errorf("GitHub returned no response for query %q", query)
 		}
-		allSearchResult = append(allSearchResult, result)
+		if err := onPage([]*github.CodeSearchResult{result}); err != nil {
+			return err
+		}
 		if nextPage <= 0 {
 			break
 		}
 		opt.Page = nextPage
 	}
-	return allSearchResult, err
+	return nil
 }
 
 func BuildQuery(query string) (string, error) {

--- a/server/search/githubsearch/search_test.go
+++ b/server/search/githubsearch/search_test.go
@@ -183,6 +183,37 @@ func TestSearchCodeByOptRetriesAfterRotatingOnPrimaryRateLimit(t *testing.T) {
 	}
 }
 
+func TestSearchCodeStreamInvokesCallbackBeforeNextPage(t *testing.T) {
+	requestCount := 0
+	callbackCount := 0
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Link", "<https://api.github.com/search/code?page=2>; rel=\"next\"")
+			writeSearchSuccess(w, github.CodeSearchResult{CodeResults: []*github.CodeResult{{Path: github.String("first.go")}}})
+			return
+		}
+		writeSearchSuccess(w, github.CodeSearchResult{CodeResults: []*github.CodeResult{{Path: github.String("second.go")}}})
+	})
+
+	err := client.SearchCodeStream("test query", func(page []*github.CodeSearchResult) error {
+		callbackCount++
+		if requestCount != callbackCount {
+			t.Fatalf("callback ran after requesting a later page: requests=%d callbacks=%d", requestCount, callbackCount)
+		}
+		if len(page) != 1 || len(page[0].CodeResults) != 1 {
+			t.Fatalf("unexpected page: %#v", page)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requestCount != 2 || callbackCount != 2 {
+		t.Fatalf("requests=%d callbacks=%d, want 2 each", requestCount, callbackCount)
+	}
+}
+
 func TestSearchCodeByOptSleepsAndRetriesWhenRotationUnavailable(t *testing.T) {
 	slept := stubSleep(t)
 	requestCount := 0

--- a/server/search/gitlabsearch/search.go
+++ b/server/search/gitlabsearch/search.go
@@ -25,6 +25,7 @@ const (
 	defaultGitlabDiscoverPages   = 5
 	defaultGitlabBatchSize       = 50
 	maxConcurrentProjectSearches = 5
+	gitlabRequestTimeout         = 2 * time.Minute
 )
 
 var (
@@ -92,15 +93,17 @@ func isGlobalSearchUnsupported(resp *gitlab.Response) bool {
 // Ultimate with it turned on) get full global coverage here.
 func RunGlobalSearchTask(client *gitlab.Client, rules []model.Rule) bool {
 	for i, rule := range rules {
-		blobs, resp, ok := SearchBlobs(client, rule.Content)
+		resp, ok := SearchBlobsStream(client, rule.Content, func(blobs []*gitlab.Blob) error {
+			results := ConvertBlobsToResults(client, blobs, rule.Content)
+			SaveResult(results, &rule.Content)
+			return nil
+		})
 		if !ok {
 			if i == 0 && isGlobalSearchUnsupported(resp) {
 				return false
 			}
 			continue
 		}
-		results := ConvertBlobsToResults(client, blobs, rule.Content)
-		SaveResult(results, &rule.Content)
 	}
 	return true
 }
@@ -147,8 +150,12 @@ func RunSearchTaskByProject(projects []model.Repo, rules []model.Rule, client *g
 
 func searchProjectForRules(project model.Repo, rules []model.Rule, client *gitlab.Client) {
 	for _, rule := range rules {
-		results := SearchCode(rule.Content, project, client)
-		SaveResult(results, &rule.Content)
+		if err := SearchCodeStream(rule.Content, project, client, func(results []*model.SearchResult) error {
+			SaveResult(results, &rule.Content)
+			return nil
+		}); err != nil {
+			global.GVA_LOG.Error("search project stream error", zap.Error(err), zap.String("project", project.Path))
+		}
 	}
 	project.Status = 1
 	if err := service.UpdateRepo(project); err != nil {
@@ -168,18 +175,29 @@ func SaveResult(results []*model.SearchResult, keyword *string) {
 // every page of results.
 func SearchCode(keyword string, project model.Repo, client *gitlab.Client) []*model.SearchResult {
 	codeResults := make([]*model.SearchResult, 0)
+	_ = SearchCodeStream(keyword, project, client, func(results []*model.SearchResult) error {
+		codeResults = append(codeResults, results...)
+		return nil
+	})
+	return codeResults
+}
+
+// SearchCodeStream searches one project page by page and lets the caller
+// persist each page before the next page is fetched.
+func SearchCodeStream(keyword string, project model.Repo, client *gitlab.Client, onPage func([]*model.SearchResult) error) error {
 	global.GVA_LOG.Info(fmt.Sprintf("Search inside project %s", project.Path))
 	opt := &gitlab.SearchOptions{Page: 1, PerPage: 100}
 	for {
 		results, resp, err := client.Search.BlobsByProject(project.ProjectId, keyword, opt)
 		if err != nil {
 			global.GVA_LOG.Error("search inside project error", zap.Error(err))
-			break
+			return err
 		}
 		if resp != nil && resp.StatusCode != http.StatusOK {
 			global.GVA_LOG.Info(fmt.Sprintf("Request error for project statuscode %d", resp.StatusCode))
-			break
+			return fmt.Errorf("search project returned status %d", resp.StatusCode)
 		}
+		pageResults := make([]*model.SearchResult, 0, len(results))
 		for _, result := range results {
 			url := project.Url + "/blob/master/" + result.Filename
 			textMatches := make([]model.TextMatch, 0)
@@ -199,14 +217,17 @@ func SearchCode(keyword string, project model.Repo, client *gitlab.Client) []*mo
 				Status:          0,
 				Keyword:         keyword,
 			}
-			codeResults = append(codeResults, &codeResult)
+			pageResults = append(pageResults, &codeResult)
+		}
+		if err := onPage(pageResults); err != nil {
+			return err
 		}
 		if resp == nil || resp.NextPage == 0 {
 			break
 		}
 		opt.Page = resp.NextPage
 	}
-	return codeResults
+	return nil
 }
 
 // ListValidProjects returns every known gitlab repo that hasn't been searched
@@ -238,7 +259,10 @@ func GetClient() *gitlab.Client {
 	if len(tokens) == 0 {
 		return nil
 	}
-	client, err := gitlab.NewClient(tokens[0].Content, gitlab.WithBaseURL(baseURL))
+	client, err := gitlab.NewClient(tokens[0].Content,
+		gitlab.WithBaseURL(baseURL),
+		gitlab.WithHTTPClient(&http.Client{Timeout: gitlabRequestTimeout}),
+	)
 	if err != nil {
 		global.GVA_LOG.Error("getClient error", zap.Error(err))
 	}
@@ -258,20 +282,32 @@ func SearchBlobBySearchOptions(client *gitlab.Client, keyword string, searchOpti
 // so callers can tell "unsupported" apart from a transient error.
 func SearchBlobs(client *gitlab.Client, keyword string) ([]*gitlab.Blob, *gitlab.Response, bool) {
 	blobs := make([]*gitlab.Blob, 0)
+	resp, ok := SearchBlobsStream(client, keyword, func(page []*gitlab.Blob) error {
+		blobs = append(blobs, page...)
+		return nil
+	})
+	return blobs, resp, ok
+}
+
+// SearchBlobsStream fetches GitLab global-search pages one at a time. The
+// callback runs before the next page is requested to bound retained results.
+func SearchBlobsStream(client *gitlab.Client, keyword string, onPage func([]*gitlab.Blob) error) (*gitlab.Response, bool) {
 	opt := &gitlab.SearchOptions{Page: 1, PerPage: 100}
 	for {
 		page, resp, err := SearchBlobBySearchOptions(client, keyword, opt)
 		if err != nil {
 			global.GVA_LOG.Error("SearchBlobs error", zap.Error(err))
-			return blobs, resp, false
+			return resp, false
 		}
-		blobs = append(blobs, page...)
+		if err := onPage(page); err != nil {
+			return resp, false
+		}
 		if resp == nil || resp.NextPage == 0 {
 			break
 		}
 		opt.Page = resp.NextPage
 	}
-	return blobs, nil, true
+	return nil, true
 }
 
 // GetProjectById is utilized to get the project by id

--- a/server/search/gitlabsearch/search_test.go
+++ b/server/search/gitlabsearch/search_test.go
@@ -244,3 +244,35 @@ func TestSearchCodePaginatesAcrossPages(t *testing.T) {
 		t.Fatalf("expected results from both pages, got %d", len(results))
 	}
 }
+
+func TestSearchCodeStreamInvokesCallbackPerPage(t *testing.T) {
+	requestCount := 0
+	callbackCount := 0
+	client := newTestGitlabClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("X-Next-Page", "2")
+			writeGitlabJSON(w, http.StatusOK, []gitlab.Blob{{Filename: "a.go", Basename: "a.go"}})
+			return
+		}
+		writeGitlabJSON(w, http.StatusOK, []gitlab.Blob{{Filename: "b.go", Basename: "b.go"}})
+	})
+
+	project := model.Repo{ProjectId: 1, Url: "https://gitlab.test/group/project"}
+	err := SearchCodeStream("test-query", project, client, func(results []*model.SearchResult) error {
+		callbackCount++
+		if requestCount != callbackCount {
+			t.Fatalf("callback ran after requesting a later page: requests=%d callbacks=%d", requestCount, callbackCount)
+		}
+		if len(results) != 1 {
+			t.Fatalf("results per page = %d, want 1", len(results))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requestCount != 2 || callbackCount != 2 {
+		t.Fatalf("requests=%d callbacks=%d, want 2 each", requestCount, callbackCount)
+	}
+}

--- a/server/search/gobuster/dns.go
+++ b/server/search/gobuster/dns.go
@@ -17,7 +17,7 @@ import (
 	"time"
 )
 
-const timeout = 30 * time.Second
+const dnsRequestTimeout = 30 * time.Second
 
 func preRun(ctx context.Context, domain string) error {
 	guid := uuid.New()
@@ -41,8 +41,10 @@ func getWordlist(wordlistFile string) (*bufio.Scanner, error) {
 }
 
 func dnsLookup(ctx context.Context, domain string) ([]string, error) {
+	lookupCtx, cancel := context.WithTimeout(ctx, dnsRequestTimeout)
+	defer cancel()
 	var resolver net.Resolver
-	return resolver.LookupHost(ctx, domain)
+	return resolver.LookupHost(lookupCtx, domain)
 }
 
 func RunDNS(ctx context.Context, domain string) {

--- a/server/search/postman/search.go
+++ b/server/search/postman/search.go
@@ -19,10 +19,11 @@ import (
 )
 
 const (
-	postmanURL             = "https://api.postman.com/search"
-	postmanPageSize        = 25
-	postmanRequestTimeout  = 30 * time.Second
-	maxPostmanResponseSize = 10 << 20
+	postmanURL              = "https://api.postman.com/search"
+	postmanPageSize         = 25
+	postmanRequestTimeout   = 30 * time.Second
+	maxPostmanResponseSize  = 10 << 20
+	maxSeenPostmanResources = 4096
 )
 
 var postmanHTTPClient = &http.Client{Timeout: postmanRequestTimeout}
@@ -188,7 +189,9 @@ func searchAPIStream(client *http.Client, endpoint, rule, searchType string, onP
 	}
 
 	seenCursors := make(map[string]struct{})
-	seenResources := make(map[string]struct{})
+	seenResources := make(map[string]struct{}, maxSeenPostmanResources)
+	seenResourceOrder := make([]string, 0, maxSeenPostmanResources)
+	seenResourceNext := 0
 	cursor := ""
 	for page := 0; ; page++ {
 		color.Infof("search for the rule %s of page %d\n", rule, page)
@@ -224,6 +227,14 @@ func searchAPIStream(client *http.Client, endpoint, rule, searchType string, onP
 			if key != "" {
 				if _, exists := seenResources[key]; exists {
 					continue
+				}
+				if len(seenResourceOrder) < maxSeenPostmanResources {
+					seenResourceOrder = append(seenResourceOrder, key)
+				} else {
+					oldKey := seenResourceOrder[seenResourceNext]
+					delete(seenResources, oldKey)
+					seenResourceOrder[seenResourceNext] = key
+					seenResourceNext = (seenResourceNext + 1) % maxSeenPostmanResources
 				}
 				seenResources[key] = struct{}{}
 			}

--- a/server/search/postman/search.go
+++ b/server/search/postman/search.go
@@ -104,12 +104,12 @@ func Search(rules *[]model.Rule) error {
 }
 
 func SearchByType(keyword, searchType string) error {
-	resList, err := SearchAPI(keyword, searchType)
-	for _, res := range *resList {
+	err := SearchAPIStream(keyword, searchType, func(res PostmanRes) error {
 		results := res.ConvertToSearchResult(keyword)
 		stats := service.SaveSearchResultsWithStats(*results)
 		global.GVA_LOG.Info(stats.Summary(keyword, "Postman"))
-	}
+		return nil
+	})
 	if err != nil {
 		global.GVA_LOG.Error("postman SearchAPI err", zap.Error(err))
 	}
@@ -136,6 +136,10 @@ func SearchAPI(rule, searchType string) (*[]PostmanRes, error) {
 	return searchAPI(postmanHTTPClient, postmanURL, rule, searchType)
 }
 
+func SearchAPIStream(rule, searchType string, onPage func(PostmanRes) error) error {
+	return searchAPIStream(postmanHTTPClient, postmanURL, rule, searchType, onPage)
+}
+
 type postmanSearchRequest struct {
 	ElementType string               `json:"elementType"`
 	QueryText   string               `json:"q"`
@@ -156,8 +160,17 @@ type postmanEqualsFilter struct {
 }
 
 func searchAPI(client *http.Client, endpoint, rule, searchType string) (*[]PostmanRes, error) {
+	resList := make([]PostmanRes, 0)
+	err := searchAPIStream(client, endpoint, rule, searchType, func(page PostmanRes) error {
+		resList = append(resList, page)
+		return nil
+	})
+	return &resList, err
+}
+
+func searchAPIStream(client *http.Client, endpoint, rule, searchType string, onPage func(PostmanRes) error) error {
 	if searchType != "collection" && searchType != "request" {
-		return &[]PostmanRes{}, fmt.Errorf("unsupported Postman search type %q", searchType)
+		return fmt.Errorf("unsupported Postman search type %q", searchType)
 	}
 
 	body, err := json.Marshal(postmanSearchRequest{
@@ -171,10 +184,9 @@ func searchAPI(client *http.Client, endpoint, rule, searchType string) (*[]Postm
 		},
 	})
 	if err != nil {
-		return &[]PostmanRes{}, fmt.Errorf("marshal Postman search request: %w", err)
+		return fmt.Errorf("marshal Postman search request: %w", err)
 	}
 
-	resList := make([]PostmanRes, 0)
 	seenCursors := make(map[string]struct{})
 	seenResources := make(map[string]struct{})
 	cursor := ""
@@ -182,28 +194,28 @@ func searchAPI(client *http.Client, endpoint, rule, searchType string) (*[]Postm
 		color.Infof("search for the rule %s of page %d\n", rule, page)
 		requestURL, err := buildPostmanSearchURL(endpoint, cursor)
 		if err != nil {
-			return &resList, fmt.Errorf("build Postman search page %d URL: %w", page, err)
+			return fmt.Errorf("build Postman search page %d URL: %w", page, err)
 		}
 
 		req, err := http.NewRequest(http.MethodPost, requestURL, bytes.NewReader(body))
 		if err != nil {
-			return &resList, fmt.Errorf("create Postman search request: %w", err)
+			return fmt.Errorf("create Postman search request: %w", err)
 		}
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0")
 
 		res, err := client.Do(req)
 		if err != nil {
-			return &resList, fmt.Errorf("request Postman search page %d: %w", page, err)
+			return fmt.Errorf("request Postman search page %d: %w", page, err)
 		}
 
 		resBody, err := readPostmanResponse(res)
 		if err != nil {
-			return &resList, fmt.Errorf("read Postman search page %d: %w", page, err)
+			return fmt.Errorf("read Postman search page %d: %w", page, err)
 		}
 		var postRes PostmanRes
 		if err = json.Unmarshal(resBody, &postRes); err != nil {
-			return &resList, fmt.Errorf("decode Postman search page %d: %w", page, err)
+			return fmt.Errorf("decode Postman search page %d: %w", page, err)
 		}
 
 		uniqueResources := make([]PostmanResource, 0, len(postRes.Data))
@@ -219,7 +231,9 @@ func searchAPI(client *http.Client, endpoint, rule, searchType string) (*[]Postm
 		}
 		postRes.Data = uniqueResources
 		if len(postRes.Data) > 0 {
-			resList = append(resList, postRes)
+			if err := onPage(postRes); err != nil {
+				return err
+			}
 		}
 
 		nextCursor := postRes.Meta.NextCursor
@@ -227,12 +241,12 @@ func searchAPI(client *http.Client, endpoint, rule, searchType string) (*[]Postm
 			break
 		}
 		if _, exists := seenCursors[nextCursor]; exists {
-			return &resList, fmt.Errorf("Postman search repeated cursor on page %d", page)
+			return fmt.Errorf("Postman search repeated cursor on page %d", page)
 		}
 		seenCursors[nextCursor] = struct{}{}
 		cursor = nextCursor
 	}
-	return &resList, nil
+	return nil
 }
 
 func readPostmanResponse(res *http.Response) ([]byte, error) {

--- a/server/search/postman/search_test.go
+++ b/server/search/postman/search_test.go
@@ -141,6 +141,37 @@ func TestSearchAPIPaginatesWithOffsetsAndEscapesRule(t *testing.T) {
 	}
 }
 
+func TestSearchAPIStreamInvokesCallbackPerPage(t *testing.T) {
+	requestCount := 0
+	var pageSizes []int
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		requestCount++
+		nextCursor := ""
+		data := []map[string]interface{}{{"id": fmt.Sprintf("request-%d", requestCount)}}
+		if requestCount == 1 {
+			nextCursor = "second-page"
+		}
+		return jsonHTTPResponse(http.StatusOK, map[string]interface{}{
+			"data": data,
+			"meta": map[string]interface{}{"nextCursor": nextCursor},
+		}), nil
+	})}
+
+	err := searchAPIStream(client, "https://postman.test/search", "key", "request", func(page PostmanRes) error {
+		pageSizes = append(pageSizes, len(page.Data))
+		if requestCount != len(pageSizes) {
+			t.Fatalf("callback ran after requesting a later page: requests=%d callbacks=%d", requestCount, len(pageSizes))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(pageSizes, []int{1, 1}) {
+		t.Fatalf("page sizes = %v, want [1 1]", pageSizes)
+	}
+}
+
 func TestSearchAPIReturnsPartialPagesOnLaterFailure(t *testing.T) {
 	requestCount := 0
 	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {

--- a/server/search/scan.go
+++ b/server/search/scan.go
@@ -18,7 +18,6 @@ import (
 )
 
 var (
-	providerWatchdog        = 30 * time.Minute
 	providerHeartbeat       = 10 * time.Second
 	scanInterval            = 15 * time.Minute
 	createScanCycle         = service.CreateScanCycle
@@ -51,9 +50,7 @@ func runProvider(logID uint, name string, fn func() model.ScanOutcome) model.Sca
 		done <- fn()
 	}()
 
-	watchdog := time.NewTimer(providerWatchdog)
 	heartbeat := time.NewTicker(providerHeartbeat)
-	defer watchdog.Stop()
 	defer heartbeat.Stop()
 
 	var outcome model.ScanOutcome
@@ -68,11 +65,6 @@ func runProvider(logID uint, name string, fn func() model.ScanOutcome) model.Sca
 			if err := heartbeatScanLog(logID, heartbeatAt); err != nil {
 				global.GVA_LOG.Error("update scan heartbeat failed", zap.String("provider", name), zap.Error(err))
 			}
-		case <-watchdog.C:
-			message := fmt.Sprintf("Scan did not finish within %s", providerWatchdog)
-			global.GVA_LOG.Error(fmt.Sprintf("%s %s, moving on to the next provider", name, message))
-			outcome = model.ScanOutcome{Status: model.ScanStatusTimeout, Message: message}
-			goto Finished
 		}
 	}
 

--- a/server/search/scan_test.go
+++ b/server/search/scan_test.go
@@ -15,28 +15,25 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestRunProviderDoesNotBlockOnSlowFn(t *testing.T) {
+func TestRunProviderWaitsForSlowFnAndKeepsHeartbeat(t *testing.T) {
 	stubScanLogPersistence(t)
-	var finished model.ScanOutcome
-	finishScanLog = func(_ uint, outcome model.ScanOutcome, _, _ time.Time) error {
-		finished = outcome
+	origHeartbeat := providerHeartbeat
+	providerHeartbeat = time.Millisecond
+	heartbeats := 0
+	heartbeatScanLog = func(uint, time.Time) error {
+		heartbeats++
 		return nil
 	}
-	origWatchdog := providerWatchdog
-	origHeartbeat := providerHeartbeat
-	providerWatchdog = 10 * time.Millisecond
-	providerHeartbeat = time.Millisecond
 	defer func() {
-		providerWatchdog = origWatchdog
 		providerHeartbeat = origHeartbeat
 	}()
 
 	block := make(chan struct{})
-	defer close(block)
+	finished := make(chan model.ScanOutcome, 1)
 
 	done := make(chan struct{})
 	go func() {
-		runProvider(1, "slow", func() model.ScanOutcome {
+		finished <- runProvider(1, "slow", func() model.ScanOutcome {
 			<-block
 			return model.ScanSuccess("done")
 		})
@@ -45,22 +42,28 @@ func TestRunProviderDoesNotBlockOnSlowFn(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(1 * time.Second):
-		t.Fatal("runProvider did not return promptly when fn hung past the watchdog")
+		t.Fatal("runProvider returned before the provider completed")
+	case <-time.After(20 * time.Millisecond):
 	}
-	if finished.Status != model.ScanStatusTimeout {
-		t.Fatalf("finished status = %q, want timeout", finished.Status)
+	close(block)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runProvider did not return after the provider completed")
+	}
+	if outcome := <-finished; outcome.Status != model.ScanStatusSuccess {
+		t.Fatalf("finished status = %q, want success", outcome.Status)
+	}
+	if heartbeats == 0 {
+		t.Fatal("expected heartbeats while the provider was still running")
 	}
 }
 
 func TestRunProviderReturnsPromptlyOnFastFn(t *testing.T) {
 	stubScanLogPersistence(t)
-	origWatchdog := providerWatchdog
 	origHeartbeat := providerHeartbeat
-	providerWatchdog = 1 * time.Minute
 	providerHeartbeat = time.Minute
 	defer func() {
-		providerWatchdog = origWatchdog
 		providerHeartbeat = origHeartbeat
 	}()
 

--- a/server/search/sourcegraphsearch/search.go
+++ b/server/search/sourcegraphsearch/search.go
@@ -89,7 +89,15 @@ func RunTask() model.ScanOutcome {
 	partial := false
 	for _, rule := range rules {
 		global.GVA_LOG.Info("Search all indexed repositories in Sourcegraph", zap.String("rule", rule.Content))
-		results, warnings, searchErr := SearchForSourcegraph(rule, sourcegraphHTTPClient)
+		var inserted int
+		warnings, searchErr := SearchForSourcegraphStream(rule, sourcegraphHTTPClient, func(results []*model.SearchResult) error {
+			if len(results) == 0 {
+				return nil
+			}
+			SaveResults(results, &rule.Content)
+			inserted += len(results)
+			return nil
+		})
 		if searchErr != nil {
 			scanErrors = append(scanErrors, fmt.Errorf("search %q: %w", rule.Content, searchErr))
 			continue
@@ -100,7 +108,7 @@ func RunTask() model.ScanOutcome {
 				global.GVA_LOG.Warn("Sourcegraph returned partial search information", zap.String("rule", rule.Content), zap.String("warning", warning))
 			}
 		}
-		SaveResults(results, &rule.Content)
+		global.GVA_LOG.Info("Sourcegraph results persisted", zap.String("rule", rule.Content), zap.Int("processed", inserted))
 	}
 	if err := errors.Join(scanErrors...); err != nil {
 		return model.ScanFailed("Sourcegraph scan completed with errors: " + err.Error())
@@ -152,6 +160,18 @@ func sourcegraphToken() string {
 // Sourcegraph. count:all is intentional: unlike the retired Searchcode API,
 // this is a global search and does not require a repository list.
 func SearchForSourcegraph(rule model.Rule, client *http.Client) ([]*model.SearchResult, []string, error) {
+	results := make([]*model.SearchResult, 0)
+	warnings, err := SearchForSourcegraphStream(rule, client, func(batch []*model.SearchResult) error {
+		results = append(results, batch...)
+		return nil
+	})
+	return results, warnings, err
+}
+
+// SearchForSourcegraphStream parses the Sourcegraph stream and delivers each
+// matches event immediately. This keeps a global search from retaining all
+// matches for a rule before they are persisted.
+func SearchForSourcegraphStream(rule model.Rule, client *http.Client, onResults func([]*model.SearchResult) error) ([]string, error) {
 	query := globalQuery(rule.Content)
 	params := url.Values{}
 	params.Set("q", query)
@@ -163,7 +183,7 @@ func SearchForSourcegraph(rule model.Rule, client *http.Client) ([]*model.Search
 	endpoint := sourcegraphBaseURL() + "/.api/search/stream?" + params.Encode()
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	req.Header.Set("Accept", "text/event-stream")
 	if token := sourcegraphToken(); token != "" {
@@ -172,18 +192,17 @@ func SearchForSourcegraph(rule model.Rule, client *http.Client) ([]*model.Search
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if resp == nil {
-		return nil, nil, errors.New("Sourcegraph returned a nil response")
+		return nil, errors.New("Sourcegraph returned a nil response")
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, nil, fmt.Errorf("Sourcegraph request returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, fmt.Errorf("Sourcegraph request returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
-	results := make([]*model.SearchResult, 0)
 	warnings := make([]string, 0)
 	var streamErr error
 	if err := parseStream(resp.Body, func(eventName, data string) error {
@@ -193,10 +212,14 @@ func SearchForSourcegraph(rule model.Rule, client *http.Client) ([]*model.Search
 			if err := json.Unmarshal([]byte(data), &matches); err != nil {
 				return fmt.Errorf("decode Sourcegraph matches: %w", err)
 			}
+			results := make([]*model.SearchResult, 0, len(matches))
 			for _, match := range matches {
 				if result := convertMatch(match); result != nil {
 					results = append(results, result)
 				}
+			}
+			if err := onResults(results); err != nil {
+				return err
 			}
 		case "progress":
 			var progress progressEvent
@@ -223,12 +246,12 @@ func SearchForSourcegraph(rule model.Rule, client *http.Client) ([]*model.Search
 		}
 		return nil
 	}); err != nil {
-		return results, warnings, err
+		return warnings, err
 	}
 	if streamErr != nil {
-		return results, warnings, streamErr
+		return warnings, streamErr
 	}
-	return results, uniqueWarnings(warnings), nil
+	return uniqueWarnings(warnings), nil
 }
 
 func globalQuery(content string) string {

--- a/server/search/sourcegraphsearch/search_test.go
+++ b/server/search/sourcegraphsearch/search_test.go
@@ -84,3 +84,26 @@ func TestSearchForSourcegraphParsesMatches(t *testing.T) {
 		t.Fatalf("unexpected repository: %s", results[0].Repo)
 	}
 }
+
+func TestSearchForSourcegraphStreamInvokesCallbackPerMatchEvent(t *testing.T) {
+	callbackCount := 0
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := "event: matches\ndata: [{\"type\":\"content\",\"repository\":\"github.com/acme/one\",\"path\":\".env\",\"lineMatches\":[{\"line\":\"A=1\",\"lineNumber\":1}]}]\n\n" +
+			"event: matches\ndata: [{\"type\":\"content\",\"repository\":\"github.com/acme/two\",\"path\":\".env\",\"lineMatches\":[{\"line\":\"B=2\",\"lineNumber\":2}]}]\n\n"
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+	})}
+
+	warnings, err := SearchForSourcegraphStream(model.Rule{Content: "ghp_"}, client, func(results []*model.SearchResult) error {
+		callbackCount++
+		if len(results) != 1 {
+			t.Fatalf("results per event = %d, want 1", len(results))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("SearchForSourcegraphStream returned error: %v", err)
+	}
+	if len(warnings) != 0 || callbackCount != 2 {
+		t.Fatalf("warnings=%v callbacks=%d, want no warnings and 2 callbacks", warnings, callbackCount)
+	}
+}


### PR DESCRIPTION
## Summary
- remove the provider watchdog so long-running scans are not abandoned and orphaned goroutines are not left behind
- keep heartbeat/stale scan monitoring and add request-level HTTP/DNS timeouts
- persist GitHub, GitLab, Sourcegraph, and Postman results page by page instead of retaining full rule result sets
- add scanner Docker/Go resource guardrails and document them

## Validation
- GOCACHE=/private/tmp/gshark-go-cache GO111MODULE=on go test -short ./...
- docker compose config --quiet
- git diff --check

The existing untracked web/tests/gshark-login-verify.png was left untouched.