### PR TITLE
fix(rule): report real csv import outcome and skipped rows

### DIFF
--- a/server/api/rule.go
+++ b/server/api/rule.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/csv"
+	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/madneal/gshark/global"
 	"github.com/madneal/gshark/model"
@@ -39,25 +40,31 @@ func UploadRules(c *gin.Context) {
 		response.FailWithMessage("规则导入失败", c)
 		return
 	}
-	rules := convertCsvIntoRules(csvLines)
+	rules, skipped := convertCsvIntoRules(csvLines)
+	imported := 0
 	for _, rule := range rules {
 		if err := service.CreateRule(rule); err != nil {
 			global.GVA_LOG.Error("创建规则失败！", zap.Error(err))
-			response.FailWithMessage("创建规则失败", c)
+			response.FailWithMessage(fmt.Sprintf("规则导入中断：已导入 %d 条，跳过 %d 行，失败原因：%s",
+				imported, skipped, err.Error()), c)
 			return
 		}
+		imported++
 	}
-	response.OkWithMessage("规则导入成功", c)
+	response.OkWithDetailed(gin.H{"imported": imported, "skipped": skipped},
+		fmt.Sprintf("规则导入成功：导入 %d 条，跳过 %d 行", imported, skipped), c)
 }
 
-func convertCsvIntoRules(lines [][]string) []model.Rule {
+func convertCsvIntoRules(lines [][]string) ([]model.Rule, int) {
 	rules := make([]model.Rule, 0)
+	skipped := 0
 	for index, line := range lines {
 		if index == 0 {
 			continue
 		}
 		if len(line) < 4 {
 			global.GVA_LOG.Warn("skip invalid rule csv row", zap.Int("row", index+1))
+			skipped++
 			continue
 		}
 		rules = append(rules, model.Rule{
@@ -68,7 +75,7 @@ func convertCsvIntoRules(lines [][]string) []model.Rule {
 			Status:   true,
 		})
 	}
-	return rules
+	return rules, skipped
 }
 
 func DeleteRule(c *gin.Context) {

--- a/server/api/rule_test.go
+++ b/server/api/rule_test.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/madneal/gshark/global"
+	"go.uber.org/zap"
+)
+
+func TestConvertCsvIntoRules(t *testing.T) {
+	if global.GVA_LOG == nil {
+		global.GVA_LOG = zap.NewNop()
+	}
+	header := []string{"规则类型", "规则内容", "规则名称", "规则描述"}
+	valid := []string{"github", "sec.com.cn in:file", "域名", "描述"}
+	short := []string{"github", "sec.com.cn"}
+
+	rules, skipped := convertCsvIntoRules([][]string{header, valid, short})
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 converted rule, got %d", len(rules))
+	}
+	if skipped != 1 {
+		t.Fatalf("expected 1 skipped row, got %d", skipped)
+	}
+	got := rules[0]
+	if got.RuleType != "github" || got.Content != "sec.com.cn in:file" ||
+		got.Name != "域名" || got.Desc != "描述" || !got.Status {
+		t.Errorf("converted rule = %+v", got)
+	}
+}

--- a/web/src/view/rule/rule.vue
+++ b/web/src/view/rule/rule.vue
@@ -207,8 +207,12 @@ export default {
         .then(() => this.onDelete())
         .catch(() => {});
     },
-    uploadSuccess() {
-      this.$message({ type: "success", message: "规则导入成功" });
+    uploadSuccess(res) {
+      if (res && res.code === 0) {
+        this.$message({ type: "success", message: res.msg || "规则导入成功" });
+      } else {
+        this.$message({ type: "error", message: (res && res.msg) || "规则导入失败" });
+      }
       this.getTableData();
     },
     async onDelete() {


### PR DESCRIPTION
## Problem

Two UX issues in the rule CSV import flow:

1. **The import dialog always reports success.** `uploadSuccess` in `web/src/view/rule/rule.vue` fires on any HTTP 200 response, but the Gin backend reports parse failures with HTTP 200 + `{code: 7}` — so a malformed CSV shows a success toast while nothing was imported.
2. **Invalid rows are skipped silently.** `convertCsvIntoRules` drops rows with fewer than 4 columns with no feedback to the user.

While debugging a real deployment we hit exactly this: an Excel-re-encoded CSV (ANSI + broken quoting) failed server-side with `parse error on line 1, column 4: bare " in non-quoted-field`, yet the UI showed 规则导入成功 and the rule list stayed empty.

## Changes

- `server/api/rule.go`: `convertCsvIntoRules` now returns the skipped-row count; the handler tracks imported rows and responds with counts (`规则导入成功：导入 N 条，跳过 M 行`). Mid-import failures now report how many rows were imported and why the import stopped.
- `web/src/view/rule/rule.vue`: `uploadSuccess(res)` checks `res.code` and surfaces the backend message, showing an error toast on failure.

## Testing

- New unit test `TestConvertCsvIntoRules` (valid row + short row → 1 rule, 1 skipped).
- `go build ./...` and package tests pass.
- Verified end-to-end on a live deployment: a corrupted CSV now shows the failure toast with the parse error; a valid CSV shows imported/skipped counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)